### PR TITLE
Fix incorrect pg2hoa acceptance for parity games with only priority 0…

### DIFF
--- a/pg2hoa.py
+++ b/pg2hoa.py
@@ -7,7 +7,7 @@ import sys
 
 def hoaAccSign(priority):
     if priority == 0:
-        return "f"
+        return "Inf(0)"
     rec = [""] * (priority + 1)
     rec[0] = "Inf(0)"
     for p in range(1, priority):


### PR DESCRIPTION
… (#2)

* Fix incorrect acceptance condition for parity games with only priority 0

When the max priority is 0, hoaAccSign() returned "f" (false), producing "Acceptance: 1 f" which means no path is accepted. This is semantically wrong — priority 0 with max-even parity should accept all paths. The correct acceptance condition is "Inf(0)".

Fixes SYNTCOMP/hoa-tools#4

https://claude.ai/code/session_019UmybPYjUHeNncKUkaUK4H

* Add regression test suite for pg2hoa.py

Includes:
- tests/test_pg2hoa.sh: test runner that validates pg2hoa output with hoacheck
- Specific regression test for issue #4 (priority 0 acceptance condition)
- Fixtures covering priorities 0-4 and round-trip tests from real ehoa examples
- Makefile `test` target

https://claude.ai/code/session_019UmybPYjUHeNncKUkaUK4H

* Revert "Add regression test suite for pg2hoa.py"

This reverts commit 55a819ee2d295f34bfdc1953aba4cf149c9c8770.

---------