### PR TITLE
Claude/cliquegame hoa converter 4fpp y (#3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.pyc
+generators/output/
+
+# Built binaries
+hoa2aig
+hoa2pg
+hoacheck
+hoaprint

--- a/generators/cliquegame.py
+++ b/generators/cliquegame.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Clique game generator in extended HOA format.
+
+Reimplements pgsolver's ``cliquegame`` (src/lib/generators/cliquegame.ml).
+Each node i has priority i, owner i % 2 and edges to every other node
+(plus optional self-loop).
+"""
+
+import sys
+
+from hoagen import emitHoa
+
+
+def cliqueGame(n, with_self_cycles):
+    prio = list(range(n))
+    owner = [i % 2 for i in range(n)]
+    succ = [[j for j in range(n) if with_self_cycles or j != i]
+            for i in range(n)]
+    names = [f"vertex{i}" for i in range(n)]
+    emitHoa(n, prio, owner, succ, names)
+
+
+def usage():
+    print(f"{sys.argv[0]} requires 1 or 2 arguments: n [self]\n"
+          "  n:    number of vertices (positive integer)\n"
+          "  self: literal string 'self' to enable self-loops",
+          file=sys.stderr)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) not in (2, 3):
+        usage()
+        sys.exit(1)
+    try:
+        n = int(sys.argv[1])
+    except ValueError:
+        usage()
+        sys.exit(1)
+    if n <= 0:
+        usage()
+        sys.exit(1)
+    with_self_cycles = False
+    if len(sys.argv) == 3:
+        if sys.argv[2] != "self":
+            usage()
+            sys.exit(1)
+        with_self_cycles = True
+    cliqueGame(n, with_self_cycles)

--- a/generators/generate_large.py
+++ b/generators/generate_large.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Generate 20 large parity games per generator in extended HOA format.
+
+For each of ``cliquegame``, ``laddergame``, ``towersofhanoi`` and
+``steadygame`` this script produces up to 20 games with increasing
+parameters, skipping any configuration that would exceed the 10MB file
+size cap. Output files go to ``output/`` next to this script (override
+with a single argv argument).
+
+Note: ``towersofhanoi``'s reachable state space is 3^n, so only n in
+roughly 2..10 fits under 10MB. The script emits what it can and warns
+when it produces fewer than 20 games for a generator.
+"""
+
+import os
+import subprocess
+import sys
+
+MB = 1024 * 1024
+SIZE_LIMIT = 10 * MB
+PER_GEN = 20
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def params_cliquegame():
+    # n^2 edge lines dominate; n ~ 305 approaches 10MB.
+    return [(str(n),) for n in range(20, 306, 15)]
+
+
+def params_laddergame():
+    # 2n states, each with ~3 short edge lines; ~135 bytes per state.
+    return [(str(n),) for n in range(2500, 52500, 2500)]
+
+
+def params_towersofhanoi():
+    # 3^n states. n=10 is ~6.4MB, n=11 would blow past 10MB.
+    return [(str(n),) for n in range(2, 11)]
+
+
+def params_steadygame():
+    # Random game of n vertices. Seed derived from n for reproducibility.
+    return [(str(n), "5", "15", "5", "15", str(n))
+            for n in range(500, 10500, 500)]
+
+
+def run(script, args, out_path):
+    with open(out_path, "wb") as f:
+        proc = subprocess.run(
+            [sys.executable, os.path.join(HERE, script), *args],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False,
+        )
+    if proc.returncode != 0:
+        os.unlink(out_path)
+        return None, proc.stderr.decode("utf-8", errors="replace").strip()
+    if len(proc.stdout) > SIZE_LIMIT:
+        os.unlink(out_path)
+        return len(proc.stdout), "over-limit"
+    with open(out_path, "wb") as f:
+        f.write(proc.stdout)
+    return len(proc.stdout), None
+
+
+def drive(name, script, paramlist, out_dir):
+    print(f"\n=== {name} ===")
+    count = 0
+    for params in paramlist:
+        if count >= PER_GEN:
+            break
+        out_path = os.path.join(out_dir, f"{name}_{count + 1:02d}.ehoa")
+        size, err = run(script, params, out_path)
+        if err == "over-limit":
+            print(f"  skip {params}: {size / MB:.2f} MB exceeds {SIZE_LIMIT // MB} MB")
+            continue
+        if err is not None:
+            print(f"  fail {params}: {err}")
+            continue
+        count += 1
+        print(f"  {out_path}  args={' '.join(params)}  size={size / MB:.2f} MB")
+    if count < PER_GEN:
+        print(f"  WARNING: {name} produced only {count} games "
+              f"(parameter space too small for {PER_GEN} under {SIZE_LIMIT // MB} MB)")
+    return count
+
+
+def main():
+    out_dir = sys.argv[1] if len(sys.argv) > 1 else os.path.join(HERE, "output")
+    os.makedirs(out_dir, exist_ok=True)
+    plan = [
+        ("cliquegame",    "cliquegame.py",    params_cliquegame()),
+        ("laddergame",    "laddergame.py",    params_laddergame()),
+        ("towersofhanoi", "towersofhanoi.py", params_towersofhanoi()),
+        ("steadygame",    "steadygame.py",    params_steadygame()),
+    ]
+    total = 0
+    for name, script, paramlist in plan:
+        total += drive(name, script, paramlist, out_dir)
+    print(f"\nDone. Wrote {total} games to {out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/generators/hoagen.py
+++ b/generators/hoagen.py
@@ -1,0 +1,81 @@
+"""Shared helpers for emitting extended-HOA parity games.
+
+Kept deliberately small: `hoaAccSign`, `genSuccLabel` and `emitHoa` together
+produce the same output shape as ``pg2hoa.py`` so files round-trip through
+``hoa2pg`` and ``hoacheck``.
+"""
+
+import math
+import sys
+
+
+def hoaAccSign(priority):
+    if priority == 0:
+        return "Inf(0)"
+    rec = [""] * (priority + 1)
+    rec[0] = "Inf(0)"
+    for p in range(1, priority):
+        if p % 2 == 0:
+            rec[p] = f"(Inf({p}) | {rec[p - 1]})"
+        else:
+            rec[p] = f"(Fin({p}) & {rec[p - 1]})"
+    if priority % 2 == 0:
+        return f"Inf({priority}) | {rec[priority - 1]}"
+    else:
+        return f"Fin({priority}) & {rec[priority - 1]}"
+
+
+def genSuccLabel(owner_i, noAP, j):
+    negAPs = [a for a in range(noAP) if ((1 << a) & j) == 0]
+    posAPs = [a for a in range(noAP) if a not in negAPs]
+    if owner_i == 1:
+        negAPs = [a + noAP for a in negAPs]
+        posAPs = [a + noAP for a in posAPs]
+    negLabel = " & ".join([f"!{a}" for a in negAPs])
+    posLabel = " & ".join([str(a) for a in posAPs])
+    return f"{negLabel} & {posLabel}"
+
+
+def emitHoa(n_states, prio, owner, succ, names, out=sys.stdout):
+    """Write an extended-HOA file describing a parity game.
+
+    Arguments mirror the fields of pg2hoa.ParityGame: priorities, owners
+    (0 or 1), successor lists (indices into [0, n_states)) and state names.
+    """
+    maxoutdeg = max(len(s) for s in succ)
+    if maxoutdeg < 1:
+        print("Error: every vertex must have at least one successor.",
+              file=sys.stderr)
+        sys.exit(1)
+    noAP = math.floor(math.log(maxoutdeg, 2)) + 1
+    maxpriority = max(prio)
+
+    w = out.write
+
+    w("HOA: v1\n")
+    w(f"States: {n_states}\n")
+    w("Start: 0\n")
+    w(f"acc-name: parity max even {maxpriority + 1}\n")
+    sign = hoaAccSign(maxpriority)
+    w(f"Acceptance: {maxpriority + 1} {sign}\n")
+    names0 = " ".join([f"\"pl0_{i}\"" for i in range(noAP)])
+    names1 = " ".join([f"\"pl1_{i}\"" for i in range(noAP)])
+    w(f"AP: {noAP * 2} {names0} {names1}\n")
+    indices1 = " ".join([str(x) for x in range(noAP)])
+    w(f"controllable-AP: {indices1}\n")
+    w("properties: deterministic complete colored\n")
+    w("--BODY--\n")
+    for i in range(n_states):
+        w(f"State: {i} \"{names[i]}\" {{ {prio[i]} }}\n")
+        if len(succ[i]) == 1:
+            w(f"[t] {succ[i][0]}\n")
+        else:
+            allLabels = []
+            for j in range(1, len(succ[i])):
+                label = genSuccLabel(owner[i], noAP, j)
+                w(f"[{label}] {succ[i][j]}\n")
+                allLabels.append(label)
+            orLabels = " | ".join([f"({lab})" for lab in allLabels])
+            negLabels = f"!({orLabels})"
+            w(f"[{negLabels}] {succ[i][0]}\n")
+    w("--END--\n")

--- a/generators/laddergame.py
+++ b/generators/laddergame.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Ladder game generator in extended HOA format.
+
+Reimplements pgsolver's ``laddergame`` (src/lib/generators/laddergame.ml).
+Builds a cycle on m = 2n vertices; vertex v has priority v % 2, owner
+v % 2 (plr_benefits) and successors (v+1) % m and (v+2) % m.
+"""
+
+import sys
+
+from hoagen import emitHoa
+
+
+def ladderGame(n):
+    m = 2 * n
+    prio = [v % 2 for v in range(m)]
+    owner = [v % 2 for v in range(m)]
+    succ = [[(v + 1) % m, (v + 2) % m] for v in range(m)]
+    names = [f"vertex{v}" for v in range(m)]
+    emitHoa(m, prio, owner, succ, names)
+
+
+def usage():
+    print(f"{sys.argv[0]} requires one argument: n\n"
+          "  n: positive integer; produces a ladder game with 2n vertices",
+          file=sys.stderr)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        usage()
+        sys.exit(1)
+    try:
+        n = int(sys.argv[1])
+    except ValueError:
+        usage()
+        sys.exit(1)
+    if n <= 0:
+        usage()
+        sys.exit(1)
+    ladderGame(n)

--- a/generators/steadygame.py
+++ b/generators/steadygame.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Steady game generator in extended HOA format.
+
+Reimplements pgsolver's ``steadygame`` (src/lib/generators/steadygame.ml).
+Produces a random parity game with controlled in/out-degree bounds.
+
+Vertex i has priority i; the owner is chosen uniformly at random.
+Successor lists are built by repeatedly matching a random source (still
+needing out-edges) to a random target (still able to receive in-edges),
+avoiding self-loops and duplicate edges where possible. Matches the
+pgsolver behaviour including its quirk of allowing a duplicate/self-loop
+when only one target remains.
+
+CLI: steadygame.py n l h x y [seed]
+"""
+
+import random
+import sys
+
+from hoagen import emitHoa
+
+
+def steadyGame(size, outdegmin, outdegmax, indegmin, indegmax, seed=None):
+    if seed is not None:
+        random.seed(seed)
+
+    outavail = list(range(size))
+    inavail = list(range(size))
+    outtodo = size
+    intodo = size
+    pg = [[] for _ in range(size)]
+    pgtr = [0] * size
+
+    while ((outtodo > 0 and len(inavail) > 0)
+           or (intodo > 0 and len(outavail) > 0)):
+        ii = random.randrange(len(outavail))
+        i = outavail[ii]
+        forb = set(pg[i])
+        forb.add(i)
+        while True:
+            jj = random.randrange(len(inavail))
+            if inavail[jj] not in forb or len(inavail) == 1:
+                break
+        j = inavail[jj]
+        pg[i].append(j)
+        pgtr[j] += 1
+        leni = len(pg[i])
+        lenj = pgtr[j]
+        if leni == outdegmin:
+            outtodo -= 1
+        elif leni == outdegmax:
+            outavail.pop(ii)
+        if lenj == indegmin:
+            intodo -= 1
+        elif lenj == indegmax:
+            inavail.pop(jj)
+
+    prio = list(range(size))
+    owner = [random.randint(0, 1) for _ in range(size)]
+    names = [f"vertex{i}" for i in range(size)]
+
+    for i in range(size):
+        if not pg[i]:
+            print(f"Warning: vertex {i} has no successors; output is not a "
+                  "valid parity game. Increase degree bounds or n.",
+                  file=sys.stderr)
+            sys.exit(1)
+
+    emitHoa(size, prio, owner, pg, names)
+
+
+def usage():
+    print(f"{sys.argv[0]} requires 5 or 6 arguments: n l h x y [seed]\n"
+          "  n:    number of vertices (positive integer)\n"
+          "  l:    lowest possible out-degree (>= 1)\n"
+          "  h:    highest possible out-degree (>= l)\n"
+          "  x:    lowest possible in-degree (>= 1)\n"
+          "  y:    highest possible in-degree (>= x)\n"
+          "  seed: optional integer seed for reproducibility",
+          file=sys.stderr)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) not in (6, 7):
+        usage()
+        sys.exit(1)
+    try:
+        n, l, h, x, y = (int(a) for a in sys.argv[1:6])
+        seed = int(sys.argv[6]) if len(sys.argv) == 7 else None
+    except ValueError:
+        usage()
+        sys.exit(1)
+    if n <= 0 or l < 1 or x < 1 or h < l or y < x:
+        usage()
+        sys.exit(1)
+    steadyGame(n, l, h, x, y, seed)

--- a/generators/towersofhanoi.py
+++ b/generators/towersofhanoi.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Towers-of-Hanoi reachability game in extended HOA format.
+
+Reimplements pgsolver's ``towersofhanoi``
+(src/lib/generators/towersofhanoi.ml). Every node is owned by player 0
+(Even). The goal state (all disks moved from peg 0 to peg 1, with peg 2
+also empty) has priority 0 with a self-loop; every other state has
+priority 1. Thus player 0 wins iff she can reach the goal.
+
+State representation: a 3-tuple of peg contents, each peg being a tuple
+of disk sizes with the head being the top (smallest) disk.
+"""
+
+import sys
+from collections import deque
+
+from hoagen import emitHoa
+
+
+MOVES = [(0, 1, 2), (0, 2, 1), (1, 0, 2), (1, 2, 0), (2, 0, 1), (2, 1, 0)]
+
+
+def is_finished(st):
+    return len(st[0]) == 0 and len(st[2]) == 0
+
+
+def successors(st):
+    if is_finished(st):
+        return [st]  # absorbing self-loop
+    tops = tuple(peg[0] if peg else 0 for peg in st)
+    out = []
+    for f, t, _ in MOVES:
+        if tops[f] > 0 and (tops[t] == 0 or tops[f] < tops[t]):
+            nst = list(st)
+            nst[f] = st[f][1:]
+            nst[t] = (tops[f],) + st[t]
+            out.append(tuple(nst))
+    return out
+
+
+def format_state(st):
+    def fmt(peg):
+        return "[" + ",".join(str(x) for x in peg) + "]"
+    return f"{fmt(st[0])} {fmt(st[1])} {fmt(st[2])}"
+
+
+def tohGame(n):
+    init = (tuple(range(1, n + 1)), (), ())
+    index = {init: 0}
+    order = [init]
+    q = deque([init])
+    while q:
+        st = q.popleft()
+        for s in successors(st):
+            if s not in index:
+                index[s] = len(order)
+                order.append(s)
+                q.append(s)
+
+    N = len(order)
+    prio = [0 if is_finished(s) else 1 for s in order]
+    owner = [0] * N
+    succ = [[index[s] for s in successors(st)] for st in order]
+    names = [format_state(st) for st in order]
+    emitHoa(N, prio, owner, succ, names)
+
+
+def usage():
+    print(f"{sys.argv[0]} requires one argument: n\n"
+          "  n: number of disks (positive integer)",
+          file=sys.stderr)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        usage()
+        sys.exit(1)
+    try:
+        n = int(sys.argv[1])
+    except ValueError:
+        usage()
+        sys.exit(1)
+    if n <= 0:
+        usage()
+        sys.exit(1)
+    tohGame(n)

--- a/hoa.y
+++ b/hoa.y
@@ -24,6 +24,13 @@
 
 /* C declarations */
 
+/* Raise the bison parser stack cap from the 10k default so that HOA
+ * files with thousands of states / transitions (e.g. the bulk outputs
+ * from generators/generate_large.py) can be parsed without hitting a
+ * premature "memory exhausted" error. 10M stack items is ~160MB worst
+ * case, which is plenty on any machine that can hold the input file. */
+#define YYMAXDEPTH 10000000
+
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>

--- a/hoalexer.c
+++ b/hoalexer.c
@@ -8,8 +8,8 @@
 
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
-#define YY_FLEX_MINOR_VERSION 5
-#define YY_FLEX_SUBMINOR_VERSION 35
+#define YY_FLEX_MINOR_VERSION 6
+#define YY_FLEX_SUBMINOR_VERSION 4
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
 #endif
@@ -47,7 +47,6 @@ typedef int16_t flex_int16_t;
 typedef uint16_t flex_uint16_t;
 typedef int32_t flex_int32_t;
 typedef uint32_t flex_uint32_t;
-typedef uint64_t flex_uint64_t;
 #else
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
@@ -55,7 +54,6 @@ typedef int flex_int32_t;
 typedef unsigned char flex_uint8_t; 
 typedef unsigned short int flex_uint16_t;
 typedef unsigned int flex_uint32_t;
-#endif /* ! C99 */
 
 /* Limits of integral types. */
 #ifndef INT8_MIN
@@ -86,63 +84,61 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX               (~(size_t)0)
+#endif
+
+#endif /* ! C99 */
+
 #endif /* ! FLEXINT_H */
 
-#ifdef __cplusplus
+/* begin standard C++ headers. */
 
-/* The "const" storage-class-modifier is valid. */
-#define YY_USE_CONST
-
-#else	/* ! __cplusplus */
-
-/* C99 requires __STDC__ to be defined as 1. */
-#if defined (__STDC__)
-
-#define YY_USE_CONST
-
-#endif	/* defined (__STDC__) */
-#endif	/* ! __cplusplus */
-
-#ifdef YY_USE_CONST
+/* TODO: this is always defined, so inline it */
 #define yyconst const
+
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yyconst
+#define yynoreturn
 #endif
 
 /* Returned upon end-of-file. */
 #define YY_NULL 0
 
-/* Promotes a possibly negative, possibly signed char to an unsigned
- * integer for use as an array index.  If the signed char is negative,
- * we want to instead treat it as an 8-bit unsigned char, hence the
- * double cast.
+/* Promotes a possibly negative, possibly signed char to an
+ *   integer in range [0..255] for use as an array index.
  */
-#define YY_SC_TO_UI(c) ((unsigned int) (unsigned char) c)
+#define YY_SC_TO_UI(c) ((YY_CHAR) (c))
 
 /* Enter a start condition.  This macro really ought to take a parameter,
  * but we do it the disgusting crufty way forced on us by the ()-less
  * definition of BEGIN.
  */
 #define BEGIN (yy_start) = 1 + 2 *
-
 /* Translate the current start state into a value that can be later handed
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
 #define YY_START (((yy_start) - 1) / 2)
 #define YYSTATE YY_START
-
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
-
 /* Special action meaning "start processing a new file". */
-#define YY_NEW_FILE yyrestart(yyin  )
-
+#define YY_NEW_FILE yyrestart( yyin  )
 #define YY_END_OF_BUFFER_CHAR 0
 
 /* Size of default input buffer. */
 #ifndef YY_BUF_SIZE
+#ifdef __ia64__
+/* On IA-64, the buffer size is 16k, not 8k.
+ * Moreover, YY_BUF_SIZE is 2*YY_READ_BUF_SIZE in the general case.
+ * Ditto for the __ia64__ case accordingly.
+ */
+#define YY_BUF_SIZE 32768
+#else
 #define YY_BUF_SIZE 16384
+#endif /* __ia64__ */
 #endif
 
 /* The state buf must be large enough to hold one state per character in the main buffer.
@@ -159,26 +155,33 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 typedef size_t yy_size_t;
 #endif
 
-extern yy_size_t yyleng;
+extern int yyleng;
 
 extern FILE *yyin, *yyout;
 
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
-
+    
     /* Note: We specifically omit the test for yy_rule_can_match_eol because it requires
      *       access to the local variable yy_act. Since yyless() is a macro, it would break
-     *       existing scanners that call yyless() from OUTSIDE yylex. 
+     *       existing scanners that call yyless() from OUTSIDE yylex.
      *       One obvious solution it to make yy_act a global. I tried that, and saw
      *       a 5% performance hit in a non-yylineno scanner, because yy_act is
      *       normally declared as a register variable-- so it is not worth it.
      */
     #define  YY_LESS_LINENO(n) \
             do { \
-                yy_size_t yyl;\
+                int yyl;\
                 for ( yyl = n; yyl < yyleng; ++yyl )\
                     if ( yytext[yyl] == '\n' )\
+                        --yylineno;\
+            }while(0)
+    #define YY_LINENO_REWIND_TO(dst) \
+            do {\
+                const char *p;\
+                for ( p = yy_cp-1; p >= (dst); --p)\
+                    if ( *p == '\n' )\
                         --yylineno;\
             }while(0)
     
@@ -195,7 +198,6 @@ extern FILE *yyin, *yyout;
 		YY_DO_BEFORE_ACTION; /* set up yytext again */ \
 		} \
 	while ( 0 )
-
 #define unput(c) yyunput( c, (yytext_ptr)  )
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
@@ -210,12 +212,12 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	yy_size_t yy_buf_size;
+	int yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	yy_size_t yy_n_chars;
+	int yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -238,7 +240,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -266,7 +268,7 @@ struct yy_buffer_state
 /* Stack of input buffers. */
 static size_t yy_buffer_stack_top = 0; /**< index of top of stack. */
 static size_t yy_buffer_stack_max = 0; /**< capacity of stack. */
-static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
+static YY_BUFFER_STATE * yy_buffer_stack = NULL; /**< Stack as an array. */
 
 /* We provide macros for accessing buffer states in case in the
  * future we want to put the buffer states in a more general
@@ -277,7 +279,6 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 #define YY_CURRENT_BUFFER ( (yy_buffer_stack) \
                           ? (yy_buffer_stack)[(yy_buffer_stack_top)] \
                           : NULL)
-
 /* Same as previous macro, but useful when we know that the buffer stack is not
  * NULL or when we need an lvalue. For internal use only.
  */
@@ -285,11 +286,11 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 
 /* yy_hold_char holds the character lost when yytext is formed. */
 static char yy_hold_char;
-static yy_size_t yy_n_chars;		/* number of characters read into yy_ch_buf */
-yy_size_t yyleng;
+static int yy_n_chars;		/* number of characters read into yy_ch_buf */
+int yyleng;
 
 /* Points to current character in buffer. */
-static char *yy_c_buf_p = (char *) 0;
+static char *yy_c_buf_p = NULL;
 static int yy_init = 0;		/* whether we need to initialize */
 static int yy_start = 0;	/* start state number */
 
@@ -298,82 +299,78 @@ static int yy_start = 0;	/* start state number */
  */
 static int yy_did_buffer_switch_on_eof;
 
-void yyrestart (FILE *input_file  );
-void yy_switch_to_buffer (YY_BUFFER_STATE new_buffer  );
-YY_BUFFER_STATE yy_create_buffer (FILE *file,int size  );
-void yy_delete_buffer (YY_BUFFER_STATE b  );
-void yy_flush_buffer (YY_BUFFER_STATE b  );
-void yypush_buffer_state (YY_BUFFER_STATE new_buffer  );
-void yypop_buffer_state (void );
+void yyrestart ( FILE *input_file  );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer  );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size  );
+void yy_delete_buffer ( YY_BUFFER_STATE b  );
+void yy_flush_buffer ( YY_BUFFER_STATE b  );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer  );
+void yypop_buffer_state ( void );
 
-static void yyensure_buffer_stack (void );
-static void yy_load_buffer_state (void );
-static void yy_init_buffer (YY_BUFFER_STATE b,FILE *file  );
+static void yyensure_buffer_stack ( void );
+static void yy_load_buffer_state ( void );
+static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file  );
+#define YY_FLUSH_BUFFER yy_flush_buffer( YY_CURRENT_BUFFER )
 
-#define YY_FLUSH_BUFFER yy_flush_buffer(YY_CURRENT_BUFFER )
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size  );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str  );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len  );
 
-YY_BUFFER_STATE yy_scan_buffer (char *base,yy_size_t size  );
-YY_BUFFER_STATE yy_scan_string (yyconst char *yy_str  );
-YY_BUFFER_STATE yy_scan_bytes (yyconst char *bytes,yy_size_t len  );
-
-void *yyalloc (yy_size_t  );
-void *yyrealloc (void *,yy_size_t  );
-void yyfree (void *  );
+void *yyalloc ( yy_size_t  );
+void *yyrealloc ( void *, yy_size_t  );
+void yyfree ( void *  );
 
 #define yy_new_buffer yy_create_buffer
-
 #define yy_set_interactive(is_interactive) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){ \
         yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer(yyin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_is_interactive = is_interactive; \
 	}
-
 #define yy_set_bol(at_bol) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){\
         yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer(yyin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = at_bol; \
 	}
-
 #define YY_AT_BOL() (YY_CURRENT_BUFFER_LVALUE->yy_at_bol)
 
 /* Begin user sect3 */
+typedef flex_uint8_t YY_CHAR;
 
-typedef unsigned char YY_CHAR;
-
-FILE *yyin = (FILE *) 0, *yyout = (FILE *) 0;
+FILE *yyin = NULL, *yyout = NULL;
 
 typedef int yy_state_type;
 
 extern int yylineno;
-
 int yylineno = 1;
 
 extern char *yytext;
+#ifdef yytext_ptr
+#undef yytext_ptr
+#endif
 #define yytext_ptr yytext
 
-static yy_state_type yy_get_previous_state (void );
-static yy_state_type yy_try_NUL_trans (yy_state_type current_state  );
-static int yy_get_next_buffer (void );
-static void yy_fatal_error (yyconst char msg[]  );
+static yy_state_type yy_get_previous_state ( void );
+static yy_state_type yy_try_NUL_trans ( yy_state_type current_state  );
+static int yy_get_next_buffer ( void );
+static void yynoreturn yy_fatal_error ( const char* msg  );
 
 /* Done after the current pattern has been matched and before the
  * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
 	(yytext_ptr) = yy_bp; \
-	yyleng = (yy_size_t) (yy_cp - yy_bp); \
+	yyleng = (int) (yy_cp - yy_bp); \
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
-
 #define YY_NUM_RULES 36
 #define YY_END_OF_BUFFER 37
 /* This struct is not used in this scanner,
@@ -383,7 +380,7 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static yyconst flex_int16_t yy_accept[135] =
+static const flex_int16_t yy_accept[135] =
     {   0,
         0,    0,    0,    0,   37,   36,   26,   35,   36,   33,
        27,   28,   36,   36,   18,   18,   36,   24,   24,   24,
@@ -402,7 +399,7 @@ static yyconst flex_int16_t yy_accept[135] =
        24,   24,    8,    0
     } ;
 
-static yyconst flex_int32_t yy_ec[256] =
+static const YY_CHAR yy_ec[256] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    2,    3,
         1,    1,    2,    1,    1,    1,    1,    1,    1,    1,
@@ -434,7 +431,7 @@ static yyconst flex_int32_t yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static yyconst flex_int32_t yy_meta[49] =
+static const YY_CHAR yy_meta[49] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    2,
         1,    1,    2,    2,    3,    1,    2,    2,    2,    2,
@@ -443,7 +440,7 @@ static yyconst flex_int32_t yy_meta[49] =
         2,    2,    2,    2,    2,    1,    1,    1
     } ;
 
-static yyconst flex_int16_t yy_base[139] =
+static const flex_int16_t yy_base[139] =
     {   0,
         0,    0,  218,  217,  225,  228,   47,  228,   46,  228,
       228,  228,  214,  214,  228,   39,    0,   39,  207,   41,
@@ -462,7 +459,7 @@ static yyconst flex_int16_t yy_base[139] =
       158,  155,  228,  228,  195,  198,  167,  200
     } ;
 
-static yyconst flex_int16_t yy_def[139] =
+static const flex_int16_t yy_def[139] =
     {   0,
       134,    1,  135,  135,  134,  134,  134,  134,  136,  134,
       134,  134,  134,  134,  134,  134,  137,  138,  138,  138,
@@ -481,7 +478,7 @@ static yyconst flex_int16_t yy_def[139] =
       138,  138,  134,    0,  134,  134,  134,  134
     } ;
 
-static yyconst flex_int16_t yy_nxt[277] =
+static const flex_int16_t yy_nxt[277] =
     {   0,
         6,    7,    7,    8,    9,   10,   11,   12,    6,   13,
         6,   14,   15,   16,    6,   17,   18,   19,   19,   19,
@@ -515,7 +512,7 @@ static yyconst flex_int16_t yy_nxt[277] =
       134,  134,  134,  134,  134,  134
     } ;
 
-static yyconst flex_int16_t yy_chk[277] =
+static const flex_int16_t yy_chk[277] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -550,7 +547,7 @@ static yyconst flex_int16_t yy_chk[277] =
     } ;
 
 /* Table of booleans, true if rule could match eol. */
-static yyconst flex_int32_t yy_rule_can_match_eol[37] =
+static const flex_int32_t yy_rule_can_match_eol[37] =
     {   0,
 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
     0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,     };
@@ -615,8 +612,9 @@ char* getAlias(char* s) {
     strcpy(str, s + 1);
     return str;
 }
+#line 616 "hoalexer.c"
 
-#line 620 "hoalexer.c"
+#line 618 "hoalexer.c"
 
 #define INITIAL 0
 #define C_COMMENT 1
@@ -633,36 +631,36 @@ char* getAlias(char* s) {
 #define YY_EXTRA_TYPE void *
 #endif
 
-static int yy_init_globals (void );
+static int yy_init_globals ( void );
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int yylex_destroy (void );
+int yylex_destroy ( void );
 
-int yyget_debug (void );
+int yyget_debug ( void );
 
-void yyset_debug (int debug_flag  );
+void yyset_debug ( int debug_flag  );
 
-YY_EXTRA_TYPE yyget_extra (void );
+YY_EXTRA_TYPE yyget_extra ( void );
 
-void yyset_extra (YY_EXTRA_TYPE user_defined  );
+void yyset_extra ( YY_EXTRA_TYPE user_defined  );
 
-FILE *yyget_in (void );
+FILE *yyget_in ( void );
 
-void yyset_in  (FILE * in_str  );
+void yyset_in  ( FILE * _in_str  );
 
-FILE *yyget_out (void );
+FILE *yyget_out ( void );
 
-void yyset_out  (FILE * out_str  );
+void yyset_out  ( FILE * _out_str  );
 
-yy_size_t yyget_leng (void );
+			int yyget_leng ( void );
 
-char *yyget_text (void );
+char *yyget_text ( void );
 
-int yyget_lineno (void );
+int yyget_lineno ( void );
 
-void yyset_lineno (int line_number  );
+void yyset_lineno ( int _line_number  );
 
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -670,35 +668,43 @@ void yyset_lineno (int line_number  );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int yywrap (void );
+extern "C" int yywrap ( void );
 #else
-extern int yywrap (void );
+extern int yywrap ( void );
 #endif
 #endif
 
-    static void yyunput (int c,char *buf_ptr  );
+#ifndef YY_NO_UNPUT
     
+    static void yyunput ( int c, char *buf_ptr  );
+    
+#endif
+
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char *,yyconst char *,int );
+static void yy_flex_strncpy ( char *, const char *, int );
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * );
+static int yy_flex_strlen ( const char * );
 #endif
 
 #ifndef YY_NO_INPUT
-
 #ifdef __cplusplus
-static int yyinput (void );
+static int yyinput ( void );
 #else
-static int input (void );
+static int input ( void );
 #endif
 
 #endif
 
 /* Amount of stuff to slurp up with each read. */
 #ifndef YY_READ_BUF_SIZE
+#ifdef __ia64__
+/* On IA-64, the buffer size is 16k, not 8k */
+#define YY_READ_BUF_SIZE 16384
+#else
 #define YY_READ_BUF_SIZE 8192
+#endif /* __ia64__ */
 #endif
 
 /* Copy whatever the last rule matched to the standard output. */
@@ -706,7 +712,7 @@ static int input (void );
 /* This used to be an fputs(), but since the string might contain NUL's,
  * we now use fwrite().
  */
-#define ECHO fwrite( yytext, yyleng, 1, yyout )
+#define ECHO do { if (fwrite( yytext, (size_t) yyleng, 1, yyout )) {} } while (0)
 #endif
 
 /* Gets input and stuffs it into "buf".  number of characters read, or YY_NULL,
@@ -717,7 +723,7 @@ static int input (void );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		yy_size_t n; \
+		int n; \
 		for ( n = 0; n < max_size && \
 			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
@@ -730,7 +736,7 @@ static int input (void );
 	else \
 		{ \
 		errno=0; \
-		while ( (result = fread(buf, 1, max_size, yyin))==0 && ferror(yyin)) \
+		while ( (result = (int) fread(buf, 1, (yy_size_t) max_size, yyin)) == 0 && ferror(yyin)) \
 			{ \
 			if( errno != EINTR) \
 				{ \
@@ -785,7 +791,7 @@ extern int yylex (void);
 
 /* Code executed at the end of each rule. */
 #ifndef YY_BREAK
-#define YY_BREAK break;
+#define YY_BREAK /*LINTED*/break;
 #endif
 
 #define YY_RULE_SETUP \
@@ -795,14 +801,10 @@ extern int yylex (void);
  */
 YY_DECL
 {
-	register yy_state_type yy_current_state;
-	register char *yy_cp, *yy_bp;
-	register int yy_act;
+	yy_state_type yy_current_state;
+	char *yy_cp, *yy_bp;
+	int yy_act;
     
-#line 52 "hoa.l"
-
-#line 805 "hoalexer.c"
-
 	if ( !(yy_init) )
 		{
 		(yy_init) = 1;
@@ -823,13 +825,18 @@ YY_DECL
 		if ( ! YY_CURRENT_BUFFER ) {
 			yyensure_buffer_stack ();
 			YY_CURRENT_BUFFER_LVALUE =
-				yy_create_buffer(yyin,YY_BUF_SIZE );
+				yy_create_buffer( yyin, YY_BUF_SIZE );
 		}
 
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 		}
 
-	while ( 1 )		/* loops until end-of-file is reached */
+	{
+#line 52 "hoa.l"
+
+#line 838 "hoalexer.c"
+
+	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
 		yy_cp = (yy_c_buf_p);
 
@@ -845,7 +852,7 @@ YY_DECL
 yy_match:
 		do
 			{
-			register YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
+			YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)] ;
 			if ( yy_accept[yy_current_state] )
 				{
 				(yy_last_accepting_state) = yy_current_state;
@@ -855,9 +862,9 @@ yy_match:
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
 				if ( yy_current_state >= 135 )
-					yy_c = yy_meta[(unsigned int) yy_c];
+					yy_c = yy_meta[yy_c];
 				}
-			yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
 		while ( yy_base[yy_current_state] != 228 );
@@ -875,10 +882,10 @@ yy_find_action:
 
 		if ( yy_act != YY_END_OF_BUFFER && yy_rule_can_match_eol[yy_act] )
 			{
-			yy_size_t yyl;
+			int yyl;
 			for ( yyl = 0; yyl < yyleng; ++yyl )
 				if ( yytext[yyl] == '\n' )
-					   
+					
     yylineno++;
 ;
 			}
@@ -1077,7 +1084,7 @@ YY_RULE_SETUP
 #line 89 "hoa.l"
 ECHO;
 	YY_BREAK
-#line 1081 "hoalexer.c"
+#line 1088 "hoalexer.c"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(C_COMMENT):
 	yyterminate();
@@ -1156,7 +1163,7 @@ case YY_STATE_EOF(C_COMMENT):
 				{
 				(yy_did_buffer_switch_on_eof) = 0;
 
-				if ( yywrap( ) )
+				if ( yywrap(  ) )
 					{
 					/* Note: because we've taken care in
 					 * yy_get_next_buffer() to have set up
@@ -1209,6 +1216,7 @@ case YY_STATE_EOF(C_COMMENT):
 			"fatal flex scanner internal error--no action found" );
 	} /* end of action switch */
 		} /* end of scanning one token */
+	} /* end of user's declarations */
 } /* end of yylex */
 
 /* yy_get_next_buffer - try to read in a new buffer
@@ -1220,9 +1228,9 @@ case YY_STATE_EOF(C_COMMENT):
  */
 static int yy_get_next_buffer (void)
 {
-    	register char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
-	register char *source = (yytext_ptr);
-	register int number_to_move, i;
+    	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
+	char *source = (yytext_ptr);
+	int number_to_move, i;
 	int ret_val;
 
 	if ( (yy_c_buf_p) > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars) + 1] )
@@ -1251,7 +1259,7 @@ static int yy_get_next_buffer (void)
 	/* Try to read more data. */
 
 	/* First move last chars to start of buffer. */
-	number_to_move = (int) ((yy_c_buf_p) - (yytext_ptr)) - 1;
+	number_to_move = (int) ((yy_c_buf_p) - (yytext_ptr) - 1);
 
 	for ( i = 0; i < number_to_move; ++i )
 		*(dest++) = *(source++);
@@ -1264,21 +1272,21 @@ static int yy_get_next_buffer (void)
 
 	else
 		{
-			yy_size_t num_to_read =
+			int num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
 			{ /* Not enough room in the buffer - grow it. */
 
 			/* just a shorter name for the current buffer */
-			YY_BUFFER_STATE b = YY_CURRENT_BUFFER;
+			YY_BUFFER_STATE b = YY_CURRENT_BUFFER_LVALUE;
 
 			int yy_c_buf_p_offset =
 				(int) ((yy_c_buf_p) - b->yy_ch_buf);
 
 			if ( b->yy_is_our_buffer )
 				{
-				yy_size_t new_size = b->yy_buf_size * 2;
+				int new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -1287,11 +1295,12 @@ static int yy_get_next_buffer (void)
 
 				b->yy_ch_buf = (char *)
 					/* Include room in for 2 EOB chars. */
-					yyrealloc((void *) b->yy_ch_buf,b->yy_buf_size + 2  );
+					yyrealloc( (void *) b->yy_ch_buf,
+							 (yy_size_t) (b->yy_buf_size + 2)  );
 				}
 			else
 				/* Can't grow it, we don't own it. */
-				b->yy_ch_buf = 0;
+				b->yy_ch_buf = NULL;
 
 			if ( ! b->yy_ch_buf )
 				YY_FATAL_ERROR(
@@ -1319,7 +1328,7 @@ static int yy_get_next_buffer (void)
 		if ( number_to_move == YY_MORE_ADJ )
 			{
 			ret_val = EOB_ACT_END_OF_FILE;
-			yyrestart(yyin  );
+			yyrestart( yyin  );
 			}
 
 		else
@@ -1333,12 +1342,15 @@ static int yy_get_next_buffer (void)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if ((yy_size_t) ((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if (((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		yy_size_t new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
-		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size  );
+		int new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
+		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
+			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size  );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
+		/* "- 2" to take care of EOB's */
+		YY_CURRENT_BUFFER_LVALUE->yy_buf_size = (int) (new_size - 2);
 	}
 
 	(yy_n_chars) += number_to_move;
@@ -1354,14 +1366,14 @@ static int yy_get_next_buffer (void)
 
     static yy_state_type yy_get_previous_state (void)
 {
-	register yy_state_type yy_current_state;
-	register char *yy_cp;
+	yy_state_type yy_current_state;
+	char *yy_cp;
     
 	yy_current_state = (yy_start);
 
 	for ( yy_cp = (yytext_ptr) + YY_MORE_ADJ; yy_cp < (yy_c_buf_p); ++yy_cp )
 		{
-		register YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
+		YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
 		if ( yy_accept[yy_current_state] )
 			{
 			(yy_last_accepting_state) = yy_current_state;
@@ -1371,9 +1383,9 @@ static int yy_get_next_buffer (void)
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
 			if ( yy_current_state >= 135 )
-				yy_c = yy_meta[(unsigned int) yy_c];
+				yy_c = yy_meta[yy_c];
 			}
-		yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 		}
 
 	return yy_current_state;
@@ -1386,10 +1398,10 @@ static int yy_get_next_buffer (void)
  */
     static yy_state_type yy_try_NUL_trans  (yy_state_type yy_current_state )
 {
-	register int yy_is_jam;
-    	register char *yy_cp = (yy_c_buf_p);
+	int yy_is_jam;
+    	char *yy_cp = (yy_c_buf_p);
 
-	register YY_CHAR yy_c = 1;
+	YY_CHAR yy_c = 1;
 	if ( yy_accept[yy_current_state] )
 		{
 		(yy_last_accepting_state) = yy_current_state;
@@ -1399,17 +1411,19 @@ static int yy_get_next_buffer (void)
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
 		if ( yy_current_state >= 135 )
-			yy_c = yy_meta[(unsigned int) yy_c];
+			yy_c = yy_meta[yy_c];
 		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 	yy_is_jam = (yy_current_state == 134);
 
-	return yy_is_jam ? 0 : yy_current_state;
+		return yy_is_jam ? 0 : yy_current_state;
 }
 
-    static void yyunput (int c, register char * yy_bp )
+#ifndef YY_NO_UNPUT
+
+    static void yyunput (int c, char * yy_bp )
 {
-	register char *yy_cp;
+	char *yy_cp;
     
     yy_cp = (yy_c_buf_p);
 
@@ -1419,10 +1433,10 @@ static int yy_get_next_buffer (void)
 	if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 		{ /* need to shift things up to make room */
 		/* +2 for EOB chars. */
-		register yy_size_t number_to_move = (yy_n_chars) + 2;
-		register char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
+		int number_to_move = (yy_n_chars) + 2;
+		char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
 					YY_CURRENT_BUFFER_LVALUE->yy_buf_size + 2];
-		register char *source =
+		char *source =
 				&YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[number_to_move];
 
 		while ( source > YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
@@ -1431,7 +1445,7 @@ static int yy_get_next_buffer (void)
 		yy_cp += (int) (dest - source);
 		yy_bp += (int) (dest - source);
 		YY_CURRENT_BUFFER_LVALUE->yy_n_chars =
-			(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
+			(yy_n_chars) = (int) YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
 
 		if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 			YY_FATAL_ERROR( "flex scanner push-back overflow" );
@@ -1447,6 +1461,8 @@ static int yy_get_next_buffer (void)
 	(yy_hold_char) = *yy_cp;
 	(yy_c_buf_p) = yy_cp;
 }
+
+#endif
 
 #ifndef YY_NO_INPUT
 #ifdef __cplusplus
@@ -1472,7 +1488,7 @@ static int yy_get_next_buffer (void)
 
 		else
 			{ /* need more input */
-			yy_size_t offset = (yy_c_buf_p) - (yytext_ptr);
+			int offset = (int) ((yy_c_buf_p) - (yytext_ptr));
 			++(yy_c_buf_p);
 
 			switch ( yy_get_next_buffer(  ) )
@@ -1489,13 +1505,13 @@ static int yy_get_next_buffer (void)
 					 */
 
 					/* Reset buffer status. */
-					yyrestart(yyin );
+					yyrestart( yyin );
 
 					/*FALLTHROUGH*/
 
 				case EOB_ACT_END_OF_FILE:
 					{
-					if ( yywrap( ) )
+					if ( yywrap(  ) )
 						return 0;
 
 					if ( ! (yy_did_buffer_switch_on_eof) )
@@ -1519,7 +1535,7 @@ static int yy_get_next_buffer (void)
 	(yy_hold_char) = *++(yy_c_buf_p);
 
 	if ( c == '\n' )
-		   
+		
     yylineno++;
 ;
 
@@ -1538,11 +1554,11 @@ static int yy_get_next_buffer (void)
 	if ( ! YY_CURRENT_BUFFER ){
         yyensure_buffer_stack ();
 		YY_CURRENT_BUFFER_LVALUE =
-            yy_create_buffer(yyin,YY_BUF_SIZE );
+            yy_create_buffer( yyin, YY_BUF_SIZE );
 	}
 
-	yy_init_buffer(YY_CURRENT_BUFFER,input_file );
-	yy_load_buffer_state( );
+	yy_init_buffer( YY_CURRENT_BUFFER, input_file );
+	yy_load_buffer_state(  );
 }
 
 /** Switch to a different input buffer.
@@ -1570,7 +1586,7 @@ static int yy_get_next_buffer (void)
 		}
 
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
-	yy_load_buffer_state( );
+	yy_load_buffer_state(  );
 
 	/* We don't actually know whether we did this switch during
 	 * EOF (yywrap()) processing, but the only time this flag
@@ -1598,7 +1614,7 @@ static void yy_load_buffer_state  (void)
 {
 	YY_BUFFER_STATE b;
     
-	b = (YY_BUFFER_STATE) yyalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
@@ -1607,13 +1623,13 @@ static void yy_load_buffer_state  (void)
 	/* yy_ch_buf has to be 2 characters longer than the size given because
 	 * we need to put in 2 end-of-buffer characters.
 	 */
-	b->yy_ch_buf = (char *) yyalloc(b->yy_buf_size + 2  );
+	b->yy_ch_buf = (char *) yyalloc( (yy_size_t) (b->yy_buf_size + 2)  );
 	if ( ! b->yy_ch_buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
 	b->yy_is_our_buffer = 1;
 
-	yy_init_buffer(b,file );
+	yy_init_buffer( b, file );
 
 	return b;
 }
@@ -1632,15 +1648,11 @@ static void yy_load_buffer_state  (void)
 		YY_CURRENT_BUFFER_LVALUE = (YY_BUFFER_STATE) 0;
 
 	if ( b->yy_is_our_buffer )
-		yyfree((void *) b->yy_ch_buf  );
+		yyfree( (void *) b->yy_ch_buf  );
 
-	yyfree((void *) b  );
+	yyfree( (void *) b  );
 }
 
-#ifndef __cplusplus
-extern int isatty (int );
-#endif /* __cplusplus */
-    
 /* Initializes or reinitializes a buffer.
  * This function is sometimes called more than once on the same buffer,
  * such as during a yyrestart() or at EOF.
@@ -1650,7 +1662,7 @@ extern int isatty (int );
 {
 	int oerrno = errno;
     
-	yy_flush_buffer(b );
+	yy_flush_buffer( b );
 
 	b->yy_input_file = file;
 	b->yy_fill_buffer = 1;
@@ -1693,7 +1705,7 @@ extern int isatty (int );
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
 	if ( b == YY_CURRENT_BUFFER )
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 }
 
 /** Pushes the new state onto the stack. The new state becomes
@@ -1724,7 +1736,7 @@ void yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
 
 	/* copied from yy_switch_to_buffer. */
-	yy_load_buffer_state( );
+	yy_load_buffer_state(  );
 	(yy_did_buffer_switch_on_eof) = 1;
 }
 
@@ -1743,7 +1755,7 @@ void yypop_buffer_state (void)
 		--(yy_buffer_stack_top);
 
 	if (YY_CURRENT_BUFFER) {
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 		(yy_did_buffer_switch_on_eof) = 1;
 	}
 }
@@ -1761,15 +1773,15 @@ static void yyensure_buffer_stack (void)
 		 * scanner will even need a stack. We use 2 instead of 1 to avoid an
 		 * immediate realloc on the next call.
          */
-		num_to_alloc = 1;
+      num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
 		(yy_buffer_stack) = (struct yy_buffer_state**)yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
 								);
 		if ( ! (yy_buffer_stack) )
 			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
-								  
+
 		memset((yy_buffer_stack), 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-				
+
 		(yy_buffer_stack_max) = num_to_alloc;
 		(yy_buffer_stack_top) = 0;
 		return;
@@ -1778,7 +1790,7 @@ static void yyensure_buffer_stack (void)
 	if ((yy_buffer_stack_top) >= ((yy_buffer_stack_max)) - 1){
 
 		/* Increase the buffer to prepare for a possible push. */
-		int grow_size = 8 /* arbitrary grow size */;
+		yy_size_t grow_size = 8 /* arbitrary grow size */;
 
 		num_to_alloc = (yy_buffer_stack_max) + grow_size;
 		(yy_buffer_stack) = (struct yy_buffer_state**)yyrealloc
@@ -1798,7 +1810,7 @@ static void yyensure_buffer_stack (void)
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
  * 
- * @return the newly allocated buffer state object. 
+ * @return the newly allocated buffer state object.
  */
 YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 {
@@ -1808,23 +1820,23 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
 		/* They forgot to leave room for the EOB's. */
-		return 0;
+		return NULL;
 
-	b = (YY_BUFFER_STATE) yyalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_buffer()" );
 
-	b->yy_buf_size = size - 2;	/* "- 2" to take care of EOB's */
+	b->yy_buf_size = (int) (size - 2);	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
 	b->yy_is_our_buffer = 0;
-	b->yy_input_file = 0;
+	b->yy_input_file = NULL;
 	b->yy_n_chars = b->yy_buf_size;
 	b->yy_is_interactive = 0;
 	b->yy_at_bol = 1;
 	b->yy_fill_buffer = 0;
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
-	yy_switch_to_buffer(b  );
+	yy_switch_to_buffer( b  );
 
 	return b;
 }
@@ -1837,28 +1849,29 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
  * @note If you want to scan bytes that may contain NUL values, then use
  *       yy_scan_bytes() instead.
  */
-YY_BUFFER_STATE yy_scan_string (yyconst char * yystr )
+YY_BUFFER_STATE yy_scan_string (const char * yystr )
 {
     
-	return yy_scan_bytes(yystr,strlen(yystr) );
+	return yy_scan_bytes( yystr, (int) strlen(yystr) );
 }
 
 /** Setup the input buffer state to scan the given bytes. The next call to yylex() will
  * scan from a @e copy of @a bytes.
- * @param bytes the byte buffer to scan
- * @param len the number of bytes in the buffer pointed to by @a bytes.
+ * @param yybytes the byte buffer to scan
+ * @param _yybytes_len the number of bytes in the buffer pointed to by @a bytes.
  * 
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len )
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len )
 {
 	YY_BUFFER_STATE b;
 	char *buf;
-	yy_size_t n, i;
+	yy_size_t n;
+	int i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
-	n = _yybytes_len + 2;
-	buf = (char *) yyalloc(n  );
+	n = (yy_size_t) (_yybytes_len + 2);
+	buf = (char *) yyalloc( n  );
 	if ( ! buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_bytes()" );
 
@@ -1867,7 +1880,7 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len 
 
 	buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
 
-	b = yy_scan_buffer(buf,n );
+	b = yy_scan_buffer( buf, n );
 	if ( ! b )
 		YY_FATAL_ERROR( "bad buffer in yy_scan_bytes()" );
 
@@ -1883,9 +1896,9 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len 
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yy_fatal_error (yyconst char* msg )
+static void yynoreturn yy_fatal_error (const char* msg )
 {
-    	(void) fprintf( stderr, "%s\n", msg );
+			fprintf( stderr, "%s\n", msg );
 	exit( YY_EXIT_FAILURE );
 }
 
@@ -1913,7 +1926,7 @@ static void yy_fatal_error (yyconst char* msg )
  */
 int yyget_lineno  (void)
 {
-        
+    
     return yylineno;
 }
 
@@ -1936,7 +1949,7 @@ FILE *yyget_out  (void)
 /** Get the length of the current token.
  * 
  */
-yy_size_t yyget_leng  (void)
+int yyget_leng  (void)
 {
         return yyleng;
 }
@@ -1951,29 +1964,29 @@ char *yyget_text  (void)
 }
 
 /** Set the current line number.
- * @param line_number
+ * @param _line_number line number
  * 
  */
-void yyset_lineno (int  line_number )
+void yyset_lineno (int  _line_number )
 {
     
-    yylineno = line_number;
+    yylineno = _line_number;
 }
 
 /** Set the input stream. This does not discard the current
  * input buffer.
- * @param in_str A readable stream.
+ * @param _in_str A readable stream.
  * 
  * @see yy_switch_to_buffer
  */
-void yyset_in (FILE *  in_str )
+void yyset_in (FILE *  _in_str )
 {
-        yyin = in_str ;
+        yyin = _in_str ;
 }
 
-void yyset_out (FILE *  out_str )
+void yyset_out (FILE *  _out_str )
 {
-        yyout = out_str ;
+        yyout = _out_str ;
 }
 
 int yyget_debug  (void)
@@ -1981,9 +1994,9 @@ int yyget_debug  (void)
         return yy_flex_debug;
 }
 
-void yyset_debug (int  bdebug )
+void yyset_debug (int  _bdebug )
 {
-        yy_flex_debug = bdebug ;
+        yy_flex_debug = _bdebug ;
 }
 
 static int yy_init_globals (void)
@@ -1995,10 +2008,10 @@ static int yy_init_globals (void)
     /* We do not touch yylineno unless the option is enabled. */
     yylineno =  1;
     
-    (yy_buffer_stack) = 0;
+    (yy_buffer_stack) = NULL;
     (yy_buffer_stack_top) = 0;
     (yy_buffer_stack_max) = 0;
-    (yy_c_buf_p) = (char *) 0;
+    (yy_c_buf_p) = NULL;
     (yy_init) = 0;
     (yy_start) = 0;
 
@@ -2007,8 +2020,8 @@ static int yy_init_globals (void)
     yyin = stdin;
     yyout = stdout;
 #else
-    yyin = (FILE *) 0;
-    yyout = (FILE *) 0;
+    yyin = NULL;
+    yyout = NULL;
 #endif
 
     /* For future reference: Set errno on error, since we are called by
@@ -2023,7 +2036,7 @@ int yylex_destroy  (void)
     
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
-		yy_delete_buffer(YY_CURRENT_BUFFER  );
+		yy_delete_buffer( YY_CURRENT_BUFFER  );
 		YY_CURRENT_BUFFER_LVALUE = NULL;
 		yypop_buffer_state();
 	}
@@ -2044,18 +2057,19 @@ int yylex_destroy  (void)
  */
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
+static void yy_flex_strncpy (char* s1, const char * s2, int n )
 {
-	register int i;
+		
+	int i;
 	for ( i = 0; i < n; ++i )
 		s1[i] = s2[i];
 }
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * s )
+static int yy_flex_strlen (const char * s )
 {
-	register int n;
+	int n;
 	for ( n = 0; s[n]; ++n )
 		;
 
@@ -2065,11 +2079,12 @@ static int yy_flex_strlen (yyconst char * s )
 
 void *yyalloc (yy_size_t  size )
 {
-	return (void *) malloc( size );
+			return malloc(size);
 }
 
 void *yyrealloc  (void * ptr, yy_size_t  size )
 {
+		
 	/* The cast to (char *) in the following accommodates both
 	 * implementations that use char* generic pointers, and those
 	 * that use void* generic pointers.  It works with the latter
@@ -2077,17 +2092,16 @@ void *yyrealloc  (void * ptr, yy_size_t  size )
 	 * any pointer type to void*, and deal with argument conversions
 	 * as though doing an assignment.
 	 */
-	return (void *) realloc( (char *) ptr, size );
+	return realloc(ptr, size);
 }
 
 void yyfree (void * ptr )
 {
-	free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
+			free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
 }
 
 #define YYTABLES_NAME "yytables"
 
 #line 89 "hoa.l"
-
 
 

--- a/hoalexer.h
+++ b/hoalexer.h
@@ -12,8 +12,8 @@
 
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
-#define YY_FLEX_MINOR_VERSION 5
-#define YY_FLEX_SUBMINOR_VERSION 35
+#define YY_FLEX_MINOR_VERSION 6
+#define YY_FLEX_SUBMINOR_VERSION 4
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
 #endif
@@ -51,7 +51,6 @@ typedef int16_t flex_int16_t;
 typedef uint16_t flex_uint16_t;
 typedef int32_t flex_int32_t;
 typedef uint32_t flex_uint32_t;
-typedef uint64_t flex_uint64_t;
 #else
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
@@ -59,7 +58,6 @@ typedef int flex_int32_t;
 typedef unsigned char flex_uint8_t; 
 typedef unsigned short int flex_uint16_t;
 typedef unsigned int flex_uint32_t;
-#endif /* ! C99 */
 
 /* Limits of integral types. */
 #ifndef INT8_MIN
@@ -90,32 +88,36 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX               (~(size_t)0)
+#endif
+
+#endif /* ! C99 */
+
 #endif /* ! FLEXINT_H */
 
-#ifdef __cplusplus
+/* begin standard C++ headers. */
 
-/* The "const" storage-class-modifier is valid. */
-#define YY_USE_CONST
-
-#else	/* ! __cplusplus */
-
-/* C99 requires __STDC__ to be defined as 1. */
-#if defined (__STDC__)
-
-#define YY_USE_CONST
-
-#endif	/* defined (__STDC__) */
-#endif	/* ! __cplusplus */
-
-#ifdef YY_USE_CONST
+/* TODO: this is always defined, so inline it */
 #define yyconst const
+
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yyconst
+#define yynoreturn
 #endif
 
 /* Size of default input buffer. */
 #ifndef YY_BUF_SIZE
+#ifdef __ia64__
+/* On IA-64, the buffer size is 16k, not 8k.
+ * Moreover, YY_BUF_SIZE is 2*YY_READ_BUF_SIZE in the general case.
+ * Ditto for the __ia64__ case accordingly.
+ */
+#define YY_BUF_SIZE 32768
+#else
 #define YY_BUF_SIZE 16384
+#endif /* __ia64__ */
 #endif
 
 #ifndef YY_TYPEDEF_YY_BUFFER_STATE
@@ -128,7 +130,7 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 typedef size_t yy_size_t;
 #endif
 
-extern yy_size_t yyleng;
+extern int yyleng;
 
 extern FILE *yyin, *yyout;
 
@@ -144,12 +146,12 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	yy_size_t yy_buf_size;
+	int yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	yy_size_t yy_n_chars;
+	int yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -172,7 +174,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -183,27 +185,30 @@ struct yy_buffer_state
 	};
 #endif /* !YY_STRUCT_YY_BUFFER_STATE */
 
-void yyrestart (FILE *input_file  );
-void yy_switch_to_buffer (YY_BUFFER_STATE new_buffer  );
-YY_BUFFER_STATE yy_create_buffer (FILE *file,int size  );
-void yy_delete_buffer (YY_BUFFER_STATE b  );
-void yy_flush_buffer (YY_BUFFER_STATE b  );
-void yypush_buffer_state (YY_BUFFER_STATE new_buffer  );
-void yypop_buffer_state (void );
+void yyrestart ( FILE *input_file  );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer  );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size  );
+void yy_delete_buffer ( YY_BUFFER_STATE b  );
+void yy_flush_buffer ( YY_BUFFER_STATE b  );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer  );
+void yypop_buffer_state ( void );
 
-YY_BUFFER_STATE yy_scan_buffer (char *base,yy_size_t size  );
-YY_BUFFER_STATE yy_scan_string (yyconst char *yy_str  );
-YY_BUFFER_STATE yy_scan_bytes (yyconst char *bytes,yy_size_t len  );
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size  );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str  );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len  );
 
-void *yyalloc (yy_size_t  );
-void *yyrealloc (void *,yy_size_t  );
-void yyfree (void *  );
+void *yyalloc ( yy_size_t  );
+void *yyrealloc ( void *, yy_size_t  );
+void yyfree ( void *  );
 
 /* Begin user sect3 */
 
 extern int yylineno;
 
 extern char *yytext;
+#ifdef yytext_ptr
+#undef yytext_ptr
+#endif
 #define yytext_ptr yytext
 
 #ifdef YY_HEADER_EXPORT_START_CONDITIONS
@@ -227,31 +232,31 @@ extern char *yytext;
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int yylex_destroy (void );
+int yylex_destroy ( void );
 
-int yyget_debug (void );
+int yyget_debug ( void );
 
-void yyset_debug (int debug_flag  );
+void yyset_debug ( int debug_flag  );
 
-YY_EXTRA_TYPE yyget_extra (void );
+YY_EXTRA_TYPE yyget_extra ( void );
 
-void yyset_extra (YY_EXTRA_TYPE user_defined  );
+void yyset_extra ( YY_EXTRA_TYPE user_defined  );
 
-FILE *yyget_in (void );
+FILE *yyget_in ( void );
 
-void yyset_in  (FILE * in_str  );
+void yyset_in  ( FILE * _in_str  );
 
-FILE *yyget_out (void );
+FILE *yyget_out ( void );
 
-void yyset_out  (FILE * out_str  );
+void yyset_out  ( FILE * _out_str  );
 
-yy_size_t yyget_leng (void );
+			int yyget_leng ( void );
 
-char *yyget_text (void );
+char *yyget_text ( void );
 
-int yyget_lineno (void );
+int yyget_lineno ( void );
 
-void yyset_lineno (int line_number  );
+void yyset_lineno ( int _line_number  );
 
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -259,18 +264,18 @@ void yyset_lineno (int line_number  );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int yywrap (void );
+extern "C" int yywrap ( void );
 #else
-extern int yywrap (void );
+extern int yywrap ( void );
 #endif
 #endif
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char *,yyconst char *,int );
+static void yy_flex_strncpy ( char *, const char *, int );
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * );
+static int yy_flex_strlen ( const char * );
 #endif
 
 #ifndef YY_NO_INPUT
@@ -279,7 +284,12 @@ static int yy_flex_strlen (yyconst char * );
 
 /* Amount of stuff to slurp up with each read. */
 #ifndef YY_READ_BUF_SIZE
+#ifdef __ia64__
+/* On IA-64, the buffer size is 16k, not 8k */
+#define YY_READ_BUF_SIZE 16384
+#else
 #define YY_READ_BUF_SIZE 8192
+#endif /* __ia64__ */
 #endif
 
 /* Number of entries by which start-condition stack grows. */
@@ -312,9 +322,154 @@ extern int yylex (void);
 #undef YY_DECL
 #endif
 
+#ifndef yy_create_buffer_ALREADY_DEFINED
+#undef yy_create_buffer
+#endif
+#ifndef yy_delete_buffer_ALREADY_DEFINED
+#undef yy_delete_buffer
+#endif
+#ifndef yy_scan_buffer_ALREADY_DEFINED
+#undef yy_scan_buffer
+#endif
+#ifndef yy_scan_string_ALREADY_DEFINED
+#undef yy_scan_string
+#endif
+#ifndef yy_scan_bytes_ALREADY_DEFINED
+#undef yy_scan_bytes
+#endif
+#ifndef yy_init_buffer_ALREADY_DEFINED
+#undef yy_init_buffer
+#endif
+#ifndef yy_flush_buffer_ALREADY_DEFINED
+#undef yy_flush_buffer
+#endif
+#ifndef yy_load_buffer_state_ALREADY_DEFINED
+#undef yy_load_buffer_state
+#endif
+#ifndef yy_switch_to_buffer_ALREADY_DEFINED
+#undef yy_switch_to_buffer
+#endif
+#ifndef yypush_buffer_state_ALREADY_DEFINED
+#undef yypush_buffer_state
+#endif
+#ifndef yypop_buffer_state_ALREADY_DEFINED
+#undef yypop_buffer_state
+#endif
+#ifndef yyensure_buffer_stack_ALREADY_DEFINED
+#undef yyensure_buffer_stack
+#endif
+#ifndef yylex_ALREADY_DEFINED
+#undef yylex
+#endif
+#ifndef yyrestart_ALREADY_DEFINED
+#undef yyrestart
+#endif
+#ifndef yylex_init_ALREADY_DEFINED
+#undef yylex_init
+#endif
+#ifndef yylex_init_extra_ALREADY_DEFINED
+#undef yylex_init_extra
+#endif
+#ifndef yylex_destroy_ALREADY_DEFINED
+#undef yylex_destroy
+#endif
+#ifndef yyget_debug_ALREADY_DEFINED
+#undef yyget_debug
+#endif
+#ifndef yyset_debug_ALREADY_DEFINED
+#undef yyset_debug
+#endif
+#ifndef yyget_extra_ALREADY_DEFINED
+#undef yyget_extra
+#endif
+#ifndef yyset_extra_ALREADY_DEFINED
+#undef yyset_extra
+#endif
+#ifndef yyget_in_ALREADY_DEFINED
+#undef yyget_in
+#endif
+#ifndef yyset_in_ALREADY_DEFINED
+#undef yyset_in
+#endif
+#ifndef yyget_out_ALREADY_DEFINED
+#undef yyget_out
+#endif
+#ifndef yyset_out_ALREADY_DEFINED
+#undef yyset_out
+#endif
+#ifndef yyget_leng_ALREADY_DEFINED
+#undef yyget_leng
+#endif
+#ifndef yyget_text_ALREADY_DEFINED
+#undef yyget_text
+#endif
+#ifndef yyget_lineno_ALREADY_DEFINED
+#undef yyget_lineno
+#endif
+#ifndef yyset_lineno_ALREADY_DEFINED
+#undef yyset_lineno
+#endif
+#ifndef yyget_column_ALREADY_DEFINED
+#undef yyget_column
+#endif
+#ifndef yyset_column_ALREADY_DEFINED
+#undef yyset_column
+#endif
+#ifndef yywrap_ALREADY_DEFINED
+#undef yywrap
+#endif
+#ifndef yyget_lval_ALREADY_DEFINED
+#undef yyget_lval
+#endif
+#ifndef yyset_lval_ALREADY_DEFINED
+#undef yyset_lval
+#endif
+#ifndef yyget_lloc_ALREADY_DEFINED
+#undef yyget_lloc
+#endif
+#ifndef yyset_lloc_ALREADY_DEFINED
+#undef yyset_lloc
+#endif
+#ifndef yyalloc_ALREADY_DEFINED
+#undef yyalloc
+#endif
+#ifndef yyrealloc_ALREADY_DEFINED
+#undef yyrealloc
+#endif
+#ifndef yyfree_ALREADY_DEFINED
+#undef yyfree
+#endif
+#ifndef yytext_ALREADY_DEFINED
+#undef yytext
+#endif
+#ifndef yyleng_ALREADY_DEFINED
+#undef yyleng
+#endif
+#ifndef yyin_ALREADY_DEFINED
+#undef yyin
+#endif
+#ifndef yyout_ALREADY_DEFINED
+#undef yyout
+#endif
+#ifndef yy_flex_debug_ALREADY_DEFINED
+#undef yy_flex_debug
+#endif
+#ifndef yylineno_ALREADY_DEFINED
+#undef yylineno
+#endif
+#ifndef yytables_fload_ALREADY_DEFINED
+#undef yytables_fload
+#endif
+#ifndef yytables_destroy_ALREADY_DEFINED
+#undef yytables_destroy
+#endif
+#ifndef yyTABLES_NAME_ALREADY_DEFINED
+#undef yyTABLES_NAME
+#endif
+
 #line 89 "hoa.l"
 
 
-#line 319 "hoalexer.h"
+#line 474 "hoalexer.h"
 #undef yyIN_HEADER
 #endif /* yyHEADER_H */

--- a/hoaparser.c
+++ b/hoaparser.c
@@ -1,14 +1,14 @@
-/* A Bison parser, made by GNU Bison 2.3.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
-/* Skeleton implementation for Bison's Yacc-like parsers in C
+/* Bison implementation for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989, 1990, 2000, 2001, 2002, 2003, 2004, 2005, 2006
-   Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
+   Inc.
 
-   This program is free software; you can redistribute it and/or modify
+   This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
-   the Free Software Foundation; either version 2, or (at your option)
-   any later version.
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
 
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -16,9 +16,7 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin Street, Fifth Floor,
-   Boston, MA 02110-1301, USA.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -36,6 +34,10 @@
 /* C LALR(1) parser skeleton written by Richard Stallman, by
    simplifying the original so-called "semantic" parser.  */
 
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
+
 /* All symbols defined below should begin with yy or YY, to avoid
    infringing on user name space.  This should be done even for local
    variables, as they might otherwise be expanded by user macros.
@@ -43,11 +45,11 @@
    define necessary library symbols; they are noted "INFRINGES ON
    USER NAME SPACE" below.  */
 
-/* Identify Bison output.  */
-#define YYBISON 1
+/* Identify Bison output, and Bison version.  */
+#define YYBISON 30802
 
-/* Bison version.  */
-#define YYBISON_VERSION "2.3"
+/* Bison version string.  */
+#define YYBISON_VERSION "3.8.2"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -55,87 +57,16 @@
 /* Pure parsers.  */
 #define YYPURE 0
 
-/* Using locations.  */
-#define YYLSP_NEEDED 1
+/* Push parsers.  */
+#define YYPUSH 0
 
-
-
-/* Tokens.  */
-#ifndef YYTOKENTYPE
-# define YYTOKENTYPE
-   /* Put the tokens into the symbol table, so that GDB and other debuggers
-      know about them.  */
-   enum yytokentype {
-     HOAHDR = 1,
-     ACCEPTANCE = 2,
-     STATES = 3,
-     AP = 4,
-     CNTAP = 5,
-     ACCNAME = 6,
-     TOOL = 7,
-     NAME = 8,
-     START = 9,
-     ALIAS = 10,
-     PROPERTIES = 11,
-     LPAR = 258,
-     RPAR = 259,
-     LBRACE = 260,
-     RBRACE = 261,
-     LSQBRACE = 262,
-     RSQBRACE = 263,
-     BOOLOR = 264,
-     BOOLAND = 265,
-     BOOLNOT = 266,
-     STATEHDR = 267,
-     INF = 268,
-     FIN = 269,
-     BEGINBODY = 270,
-     ENDBODY = 271,
-     STRING = 272,
-     IDENTIFIER = 273,
-     ANAME = 274,
-     HEADERNAME = 275,
-     INT = 276,
-     BOOL = 277
-   };
-#endif
-/* Tokens.  */
-#define HOAHDR 1
-#define ACCEPTANCE 2
-#define STATES 3
-#define AP 4
-#define CNTAP 5
-#define ACCNAME 6
-#define TOOL 7
-#define NAME 8
-#define START 9
-#define ALIAS 10
-#define PROPERTIES 11
-#define LPAR 258
-#define RPAR 259
-#define LBRACE 260
-#define RBRACE 261
-#define LSQBRACE 262
-#define RSQBRACE 263
-#define BOOLOR 264
-#define BOOLAND 265
-#define BOOLNOT 266
-#define STATEHDR 267
-#define INF 268
-#define FIN 269
-#define BEGINBODY 270
-#define ENDBODY 271
-#define STRING 272
-#define IDENTIFIER 273
-#define ANAME 274
-#define HEADERNAME 275
-#define INT 276
-#define BOOL 277
+/* Pull parsers.  */
+#define YYPULL 1
 
 
 
 
-/* Copy the first part of user declarations.  */
+/* First part of user prologue.  */
 #line 1 "hoa.y"
 
 /**************************************************************************
@@ -162,6 +93,13 @@
  *************************************************************************/
 
 /* C declarations */
+
+/* Raise the bison parser stack cap from the 10k default so that HOA
+ * files with thousands of states / transitions (e.g. the bulk outputs
+ * from generators/generate_large.py) can be parsed without hitting a
+ * premature "memory exhausted" error. 10M stack items is ~160MB worst
+ * case, which is plenty on any machine that can hold the input file. */
+#define YYMAXDEPTH 10000000
 
 #include <assert.h>
 #include <stdio.h>
@@ -222,6 +160,7 @@ typedef struct StateList {
     IntList* accSig;
     TransList* transitions;
     struct StateList* next;
+    struct StateList* last;
 } StateList;
 
 typedef struct AliasList {
@@ -336,15 +275,23 @@ static StateList* newStateNode(int id, char* name, BTree* label, IntList* accSig
     list->name = name;
     list->label = label;
     list->accSig = accSig;
+    list->next = NULL;
+    list->last = list;
     list->transitions = NULL;
     return list;
 }
 
-static StateList* prependStateNode(StateList* node, StateList* newNode,
+static StateList* appendStateNode(StateList* node, StateList* newNode,
                             TransList* transitions) {
-    newNode->next = node;
     newNode->transitions = transitions;
-    return newNode;
+    if (node == NULL) {
+        return newNode; // nothing to do
+    } else {
+        // find last in list, add it
+        node->last->next = newNode;
+        node->last = newNode;
+        return node;
+    }
 }
 
 static TransList* prependTransNode(TransList* node , BTree* label,
@@ -531,96 +478,185 @@ static BTree* accidBTree(NodeType type, int id, bool negated) {
 }
 
 
+#line 482 "hoaparser.c"
 
-/* Enabling traces.  */
-#ifndef YYDEBUG
-# define YYDEBUG 0
-#endif
+# ifndef YY_CAST
+#  ifdef __cplusplus
+#   define YY_CAST(Type, Val) static_cast<Type> (Val)
+#   define YY_REINTERPRET_CAST(Type, Val) reinterpret_cast<Type> (Val)
+#  else
+#   define YY_CAST(Type, Val) ((Type) (Val))
+#   define YY_REINTERPRET_CAST(Type, Val) ((Type) (Val))
+#  endif
+# endif
+# ifndef YY_NULLPTR
+#  if defined __cplusplus
+#   if 201103L <= __cplusplus
+#    define YY_NULLPTR nullptr
+#   else
+#    define YY_NULLPTR 0
+#   endif
+#  else
+#   define YY_NULLPTR ((void*)0)
+#  endif
+# endif
 
-/* Enabling verbose error messages.  */
-#ifdef YYERROR_VERBOSE
-# undef YYERROR_VERBOSE
-# define YYERROR_VERBOSE 1
-#else
-# define YYERROR_VERBOSE 0
-#endif
-
-/* Enabling the token table.  */
-#ifndef YYTOKEN_TABLE
-# define YYTOKEN_TABLE 0
-#endif
-
-#if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
-typedef union YYSTYPE
-#line 420 "hoa.y"
+#include "hoaparser.h"
+/* Symbol kind.  */
+enum yysymbol_kind_t
 {
-    int number;
-    char* string;
-    bool boolean;
-    NodeType nodetype;
-    void* numlist;
-    void* strlist;
-    void* trlist;
-    void* statelist;
-    BTree* tree;
-}
-/* Line 193 of yacc.c.  */
-#line 569 "hoaparser.c"
-	YYSTYPE;
-# define yystype YYSTYPE /* obsolescent; will be withdrawn */
-# define YYSTYPE_IS_DECLARED 1
-# define YYSTYPE_IS_TRIVIAL 1
-#endif
+  YYSYMBOL_YYEMPTY = -2,
+  YYSYMBOL_YYEOF = 0,                      /* "end of file"  */
+  YYSYMBOL_YYerror = 1,                    /* error  */
+  YYSYMBOL_YYUNDEF = 2,                    /* "invalid token"  */
+  YYSYMBOL_HOAHDR = 3,                     /* HOAHDR  */
+  YYSYMBOL_ACCEPTANCE = 4,                 /* ACCEPTANCE  */
+  YYSYMBOL_STATES = 5,                     /* STATES  */
+  YYSYMBOL_AP = 6,                         /* AP  */
+  YYSYMBOL_CNTAP = 7,                      /* CNTAP  */
+  YYSYMBOL_ACCNAME = 8,                    /* ACCNAME  */
+  YYSYMBOL_TOOL = 9,                       /* TOOL  */
+  YYSYMBOL_NAME = 10,                      /* NAME  */
+  YYSYMBOL_START = 11,                     /* START  */
+  YYSYMBOL_ALIAS = 12,                     /* ALIAS  */
+  YYSYMBOL_PROPERTIES = 13,                /* PROPERTIES  */
+  YYSYMBOL_LPAR = 14,                      /* "("  */
+  YYSYMBOL_RPAR = 15,                      /* ")"  */
+  YYSYMBOL_LBRACE = 16,                    /* "{"  */
+  YYSYMBOL_RBRACE = 17,                    /* "}"  */
+  YYSYMBOL_LSQBRACE = 18,                  /* "["  */
+  YYSYMBOL_RSQBRACE = 19,                  /* "]"  */
+  YYSYMBOL_BOOLOR = 20,                    /* "|"  */
+  YYSYMBOL_BOOLAND = 21,                   /* "&"  */
+  YYSYMBOL_BOOLNOT = 22,                   /* "!"  */
+  YYSYMBOL_STATEHDR = 23,                  /* STATEHDR  */
+  YYSYMBOL_INF = 24,                       /* INF  */
+  YYSYMBOL_FIN = 25,                       /* FIN  */
+  YYSYMBOL_BEGINBODY = 26,                 /* BEGINBODY  */
+  YYSYMBOL_ENDBODY = 27,                   /* ENDBODY  */
+  YYSYMBOL_STRING = 28,                    /* STRING  */
+  YYSYMBOL_IDENTIFIER = 29,                /* IDENTIFIER  */
+  YYSYMBOL_ANAME = 30,                     /* ANAME  */
+  YYSYMBOL_HEADERNAME = 31,                /* HEADERNAME  */
+  YYSYMBOL_INT = 32,                       /* INT  */
+  YYSYMBOL_BOOL = 33,                      /* BOOL  */
+  YYSYMBOL_YYACCEPT = 34,                  /* $accept  */
+  YYSYMBOL_automaton = 35,                 /* automaton  */
+  YYSYMBOL_header = 36,                    /* header  */
+  YYSYMBOL_format_version = 37,            /* format_version  */
+  YYSYMBOL_header_list = 38,               /* header_list  */
+  YYSYMBOL_header_item = 39,               /* header_item  */
+  YYSYMBOL_state_conj = 40,                /* state_conj  */
+  YYSYMBOL_label_expr = 41,                /* label_expr  */
+  YYSYMBOL_lab_exp_conj = 42,              /* lab_exp_conj  */
+  YYSYMBOL_lab_exp_atom = 43,              /* lab_exp_atom  */
+  YYSYMBOL_acceptance_cond = 44,           /* acceptance_cond  */
+  YYSYMBOL_acc_cond_conj = 45,             /* acc_cond_conj  */
+  YYSYMBOL_acc_cond_atom = 46,             /* acc_cond_atom  */
+  YYSYMBOL_accid = 47,                     /* accid  */
+  YYSYMBOL_boolintid_list = 48,            /* boolintid_list  */
+  YYSYMBOL_boolintstrid_list = 49,         /* boolintstrid_list  */
+  YYSYMBOL_string_list = 50,               /* string_list  */
+  YYSYMBOL_id_list = 51,                   /* id_list  */
+  YYSYMBOL_body = 52,                      /* body  */
+  YYSYMBOL_statespec_list = 53,            /* statespec_list  */
+  YYSYMBOL_state_name = 54,                /* state_name  */
+  YYSYMBOL_maybe_label = 55,               /* maybe_label  */
+  YYSYMBOL_maybe_string = 56,              /* maybe_string  */
+  YYSYMBOL_maybe_accsig = 57,              /* maybe_accsig  */
+  YYSYMBOL_int_list = 58,                  /* int_list  */
+  YYSYMBOL_trans_list = 59                 /* trans_list  */
+};
+typedef enum yysymbol_kind_t yysymbol_kind_t;
 
-#if ! defined YYLTYPE && ! defined YYLTYPE_IS_DECLARED
-typedef struct YYLTYPE
-{
-  int first_line;
-  int first_column;
-  int last_line;
-  int last_column;
-} YYLTYPE;
-# define yyltype YYLTYPE /* obsolescent; will be withdrawn */
-# define YYLTYPE_IS_DECLARED 1
-# define YYLTYPE_IS_TRIVIAL 1
-#endif
 
 
-/* Copy the second part of user declarations.  */
-
-
-/* Line 216 of yacc.c.  */
-#line 594 "hoaparser.c"
 
 #ifdef short
 # undef short
 #endif
 
-#ifdef YYTYPE_UINT8
-typedef YYTYPE_UINT8 yytype_uint8;
-#else
-typedef unsigned char yytype_uint8;
+/* On compilers that do not define __PTRDIFF_MAX__ etc., make sure
+   <limits.h> and (if available) <stdint.h> are included
+   so that the code can choose integer types of a good width.  */
+
+#ifndef __PTRDIFF_MAX__
+# include <limits.h> /* INFRINGES ON USER NAME SPACE */
+# if defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
+#  include <stdint.h> /* INFRINGES ON USER NAME SPACE */
+#  define YY_STDINT_H
+# endif
 #endif
 
-#ifdef YYTYPE_INT8
-typedef YYTYPE_INT8 yytype_int8;
-#elif (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+/* Narrow types that promote to a signed type and that can represent a
+   signed or unsigned integer of at least N bits.  In tables they can
+   save space and decrease cache pressure.  Promoting to a signed type
+   helps avoid bugs in integer arithmetic.  */
+
+#ifdef __INT_LEAST8_MAX__
+typedef __INT_LEAST8_TYPE__ yytype_int8;
+#elif defined YY_STDINT_H
+typedef int_least8_t yytype_int8;
+#else
 typedef signed char yytype_int8;
-#else
-typedef short int yytype_int8;
 #endif
 
-#ifdef YYTYPE_UINT16
-typedef YYTYPE_UINT16 yytype_uint16;
+#ifdef __INT_LEAST16_MAX__
+typedef __INT_LEAST16_TYPE__ yytype_int16;
+#elif defined YY_STDINT_H
+typedef int_least16_t yytype_int16;
 #else
-typedef unsigned short int yytype_uint16;
+typedef short yytype_int16;
 #endif
 
-#ifdef YYTYPE_INT16
-typedef YYTYPE_INT16 yytype_int16;
+/* Work around bug in HP-UX 11.23, which defines these macros
+   incorrectly for preprocessor constants.  This workaround can likely
+   be removed in 2023, as HPE has promised support for HP-UX 11.23
+   (aka HP-UX 11i v2) only through the end of 2022; see Table 2 of
+   <https://h20195.www2.hpe.com/V2/getpdf.aspx/4AA4-7673ENW.pdf>.  */
+#ifdef __hpux
+# undef UINT_LEAST8_MAX
+# undef UINT_LEAST16_MAX
+# define UINT_LEAST8_MAX 255
+# define UINT_LEAST16_MAX 65535
+#endif
+
+#if defined __UINT_LEAST8_MAX__ && __UINT_LEAST8_MAX__ <= __INT_MAX__
+typedef __UINT_LEAST8_TYPE__ yytype_uint8;
+#elif (!defined __UINT_LEAST8_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST8_MAX <= INT_MAX)
+typedef uint_least8_t yytype_uint8;
+#elif !defined __UINT_LEAST8_MAX__ && UCHAR_MAX <= INT_MAX
+typedef unsigned char yytype_uint8;
 #else
-typedef short int yytype_int16;
+typedef short yytype_uint8;
+#endif
+
+#if defined __UINT_LEAST16_MAX__ && __UINT_LEAST16_MAX__ <= __INT_MAX__
+typedef __UINT_LEAST16_TYPE__ yytype_uint16;
+#elif (!defined __UINT_LEAST16_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST16_MAX <= INT_MAX)
+typedef uint_least16_t yytype_uint16;
+#elif !defined __UINT_LEAST16_MAX__ && USHRT_MAX <= INT_MAX
+typedef unsigned short yytype_uint16;
+#else
+typedef int yytype_uint16;
+#endif
+
+#ifndef YYPTRDIFF_T
+# if defined __PTRDIFF_TYPE__ && defined __PTRDIFF_MAX__
+#  define YYPTRDIFF_T __PTRDIFF_TYPE__
+#  define YYPTRDIFF_MAXIMUM __PTRDIFF_MAX__
+# elif defined PTRDIFF_MAX
+#  ifndef ptrdiff_t
+#   include <stddef.h> /* INFRINGES ON USER NAME SPACE */
+#  endif
+#  define YYPTRDIFF_T ptrdiff_t
+#  define YYPTRDIFF_MAXIMUM PTRDIFF_MAX
+# else
+#  define YYPTRDIFF_T long
+#  define YYPTRDIFF_MAXIMUM LONG_MAX
+# endif
 #endif
 
 #ifndef YYSIZE_T
@@ -628,55 +664,106 @@ typedef short int yytype_int16;
 #  define YYSIZE_T __SIZE_TYPE__
 # elif defined size_t
 #  define YYSIZE_T size_t
-# elif ! defined YYSIZE_T && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+# elif defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
 #  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
 #  define YYSIZE_T size_t
 # else
-#  define YYSIZE_T unsigned int
+#  define YYSIZE_T unsigned
 # endif
 #endif
 
-#define YYSIZE_MAXIMUM ((YYSIZE_T) -1)
+#define YYSIZE_MAXIMUM                                  \
+  YY_CAST (YYPTRDIFF_T,                                 \
+           (YYPTRDIFF_MAXIMUM < YY_CAST (YYSIZE_T, -1)  \
+            ? YYPTRDIFF_MAXIMUM                         \
+            : YY_CAST (YYSIZE_T, -1)))
+
+#define YYSIZEOF(X) YY_CAST (YYPTRDIFF_T, sizeof (X))
+
+
+/* Stored state numbers (used for stacks). */
+typedef yytype_int8 yy_state_t;
+
+/* State numbers in computations.  */
+typedef int yy_state_fast_t;
 
 #ifndef YY_
 # if defined YYENABLE_NLS && YYENABLE_NLS
 #  if ENABLE_NLS
 #   include <libintl.h> /* INFRINGES ON USER NAME SPACE */
-#   define YY_(msgid) dgettext ("bison-runtime", msgid)
+#   define YY_(Msgid) dgettext ("bison-runtime", Msgid)
 #  endif
 # endif
 # ifndef YY_
-#  define YY_(msgid) msgid
+#  define YY_(Msgid) Msgid
+# endif
+#endif
+
+
+#ifndef YY_ATTRIBUTE_PURE
+# if defined __GNUC__ && 2 < __GNUC__ + (96 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_PURE __attribute__ ((__pure__))
+# else
+#  define YY_ATTRIBUTE_PURE
+# endif
+#endif
+
+#ifndef YY_ATTRIBUTE_UNUSED
+# if defined __GNUC__ && 2 < __GNUC__ + (7 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_UNUSED __attribute__ ((__unused__))
+# else
+#  define YY_ATTRIBUTE_UNUSED
 # endif
 #endif
 
 /* Suppress unused-variable warnings by "using" E.  */
 #if ! defined lint || defined __GNUC__
-# define YYUSE(e) ((void) (e))
+# define YY_USE(E) ((void) (E))
 #else
-# define YYUSE(e) /* empty */
+# define YY_USE(E) /* empty */
 #endif
 
-/* Identity function, used to suppress warnings about constant conditions.  */
-#ifndef lint
-# define YYID(n) (n)
+/* Suppress an incorrect diagnostic about yylval being uninitialized.  */
+#if defined __GNUC__ && ! defined __ICC && 406 <= __GNUC__ * 100 + __GNUC_MINOR__
+# if __GNUC__ * 100 + __GNUC_MINOR__ < 407
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")
+# else
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")              \
+    _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
+# endif
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END      \
+    _Pragma ("GCC diagnostic pop")
 #else
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-static int
-YYID (int i)
-#else
-static int
-YYID (i)
-    int i;
+# define YY_INITIAL_VALUE(Value) Value
 #endif
-{
-  return i;
-}
+#ifndef YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END
+#endif
+#ifndef YY_INITIAL_VALUE
+# define YY_INITIAL_VALUE(Value) /* Nothing. */
 #endif
 
-#if ! defined yyoverflow || YYERROR_VERBOSE
+#if defined __cplusplus && defined __GNUC__ && ! defined __ICC && 6 <= __GNUC__
+# define YY_IGNORE_USELESS_CAST_BEGIN                          \
+    _Pragma ("GCC diagnostic push")                            \
+    _Pragma ("GCC diagnostic ignored \"-Wuseless-cast\"")
+# define YY_IGNORE_USELESS_CAST_END            \
+    _Pragma ("GCC diagnostic pop")
+#endif
+#ifndef YY_IGNORE_USELESS_CAST_BEGIN
+# define YY_IGNORE_USELESS_CAST_BEGIN
+# define YY_IGNORE_USELESS_CAST_END
+#endif
+
+
+#define YY_ASSERT(E) ((void) (0 && (E)))
+
+#if !defined yyoverflow
 
 /* The parser invokes alloca or malloc; define the necessary symbols.  */
 
@@ -693,11 +780,11 @@ YYID (i)
 #    define alloca _alloca
 #   else
 #    define YYSTACK_ALLOC alloca
-#    if ! defined _ALLOCA_H && ! defined _STDLIB_H && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+#    if ! defined _ALLOCA_H && ! defined EXIT_SUCCESS
 #     include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
-#     ifndef _STDLIB_H
-#      define _STDLIB_H 1
+      /* Use EXIT_SUCCESS as a witness for stdlib.h.  */
+#     ifndef EXIT_SUCCESS
+#      define EXIT_SUCCESS 0
 #     endif
 #    endif
 #   endif
@@ -705,8 +792,8 @@ YYID (i)
 # endif
 
 # ifdef YYSTACK_ALLOC
-   /* Pacify GCC's `empty if-body' warning.  */
-#  define YYSTACK_FREE(Ptr) do { /* empty */; } while (YYID (0))
+   /* Pacify GCC's 'empty if-body' warning.  */
+#  define YYSTACK_FREE(Ptr) do { /* empty */; } while (0)
 #  ifndef YYSTACK_ALLOC_MAXIMUM
     /* The OS might guarantee only one guard page at the bottom of the stack,
        and a page size can be as small as 4096 bytes.  So we cannot safely
@@ -720,94 +807,96 @@ YYID (i)
 #  ifndef YYSTACK_ALLOC_MAXIMUM
 #   define YYSTACK_ALLOC_MAXIMUM YYSIZE_MAXIMUM
 #  endif
-#  if (defined __cplusplus && ! defined _STDLIB_H \
+#  if (defined __cplusplus && ! defined EXIT_SUCCESS \
        && ! ((defined YYMALLOC || defined malloc) \
-	     && (defined YYFREE || defined free)))
+             && (defined YYFREE || defined free)))
 #   include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
-#   ifndef _STDLIB_H
-#    define _STDLIB_H 1
+#   ifndef EXIT_SUCCESS
+#    define EXIT_SUCCESS 0
 #   endif
 #  endif
 #  ifndef YYMALLOC
 #   define YYMALLOC malloc
-#   if ! defined malloc && ! defined _STDLIB_H && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+#   if ! defined malloc && ! defined EXIT_SUCCESS
 void *malloc (YYSIZE_T); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
 #  ifndef YYFREE
 #   define YYFREE free
-#   if ! defined free && ! defined _STDLIB_H && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+#   if ! defined free && ! defined EXIT_SUCCESS
 void free (void *); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
 # endif
-#endif /* ! defined yyoverflow || YYERROR_VERBOSE */
-
+#endif /* !defined yyoverflow */
 
 #if (! defined yyoverflow \
      && (! defined __cplusplus \
-	 || (defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL \
-	     && defined YYSTYPE_IS_TRIVIAL && YYSTYPE_IS_TRIVIAL)))
+         || (defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL \
+             && defined YYSTYPE_IS_TRIVIAL && YYSTYPE_IS_TRIVIAL)))
 
 /* A type that is properly aligned for any stack member.  */
 union yyalloc
 {
-  yytype_int16 yyss;
-  YYSTYPE yyvs;
-    YYLTYPE yyls;
+  yy_state_t yyss_alloc;
+  YYSTYPE yyvs_alloc;
+  YYLTYPE yyls_alloc;
 };
 
 /* The size of the maximum gap between one aligned stack and the next.  */
-# define YYSTACK_GAP_MAXIMUM (sizeof (union yyalloc) - 1)
+# define YYSTACK_GAP_MAXIMUM (YYSIZEOF (union yyalloc) - 1)
 
 /* The size of an array large to enough to hold all stacks, each with
    N elements.  */
 # define YYSTACK_BYTES(N) \
-     ((N) * (sizeof (yytype_int16) + sizeof (YYSTYPE) + sizeof (YYLTYPE)) \
+     ((N) * (YYSIZEOF (yy_state_t) + YYSIZEOF (YYSTYPE) \
+             + YYSIZEOF (YYLTYPE)) \
       + 2 * YYSTACK_GAP_MAXIMUM)
 
-/* Copy COUNT objects from FROM to TO.  The source and destination do
-   not overlap.  */
-# ifndef YYCOPY
-#  if defined __GNUC__ && 1 < __GNUC__
-#   define YYCOPY(To, From, Count) \
-      __builtin_memcpy (To, From, (Count) * sizeof (*(From)))
-#  else
-#   define YYCOPY(To, From, Count)		\
-      do					\
-	{					\
-	  YYSIZE_T yyi;				\
-	  for (yyi = 0; yyi < (Count); yyi++)	\
-	    (To)[yyi] = (From)[yyi];		\
-	}					\
-      while (YYID (0))
-#  endif
-# endif
+# define YYCOPY_NEEDED 1
 
 /* Relocate STACK from its old location to the new one.  The
    local variables YYSIZE and YYSTACKSIZE give the old and new number of
    elements in the stack, and YYPTR gives the new location of the
    stack.  Advance YYPTR to a properly aligned location for the next
    stack.  */
-# define YYSTACK_RELOCATE(Stack)					\
-    do									\
-      {									\
-	YYSIZE_T yynewbytes;						\
-	YYCOPY (&yyptr->Stack, Stack, yysize);				\
-	Stack = &yyptr->Stack;						\
-	yynewbytes = yystacksize * sizeof (*Stack) + YYSTACK_GAP_MAXIMUM; \
-	yyptr += yynewbytes / sizeof (*yyptr);				\
-      }									\
-    while (YYID (0))
+# define YYSTACK_RELOCATE(Stack_alloc, Stack)                           \
+    do                                                                  \
+      {                                                                 \
+        YYPTRDIFF_T yynewbytes;                                         \
+        YYCOPY (&yyptr->Stack_alloc, Stack, yysize);                    \
+        Stack = &yyptr->Stack_alloc;                                    \
+        yynewbytes = yystacksize * YYSIZEOF (*Stack) + YYSTACK_GAP_MAXIMUM; \
+        yyptr += yynewbytes / YYSIZEOF (*yyptr);                        \
+      }                                                                 \
+    while (0)
 
 #endif
+
+#if defined YYCOPY_NEEDED && YYCOPY_NEEDED
+/* Copy COUNT objects from SRC to DST.  The source and destination do
+   not overlap.  */
+# ifndef YYCOPY
+#  if defined __GNUC__ && 1 < __GNUC__
+#   define YYCOPY(Dst, Src, Count) \
+      __builtin_memcpy (Dst, Src, YY_CAST (YYSIZE_T, (Count)) * sizeof (*(Src)))
+#  else
+#   define YYCOPY(Dst, Src, Count)              \
+      do                                        \
+        {                                       \
+          YYPTRDIFF_T yyi;                      \
+          for (yyi = 0; yyi < (Count); yyi++)   \
+            (Dst)[yyi] = (Src)[yyi];            \
+        }                                       \
+      while (0)
+#  endif
+# endif
+#endif /* !YYCOPY_NEEDED */
 
 /* YYFINAL -- State number of the termination state.  */
 #define YYFINAL  6
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   97
+#define YYLAST   94
 
 /* YYNTOKENS -- Number of terminals.  */
 #define YYNTOKENS  34
@@ -815,18 +904,23 @@ union yyalloc
 #define YYNNTS  26
 /* YYNRULES -- Number of rules.  */
 #define YYNRULES  65
-/* YYNRULES -- Number of states.  */
-#define YYNSTATES  111
+/* YYNSTATES -- Number of states.  */
+#define YYNSTATES  110
 
-/* YYTRANSLATE(YYLEX) -- Bison symbol number corresponding to YYLEX.  */
-#define YYUNDEFTOK  2
+/* YYMAXUTOK -- Last valid token kind.  */
 #define YYMAXUTOK   277
 
-#define YYTRANSLATE(YYX)						\
-  ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
 
-/* YYTRANSLATE[YYLEX] -- Bison symbol number corresponding to YYLEX.  */
-static const yytype_uint8 yytranslate[] =
+/* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
+   as returned by yylex, with out-of-bounds checking.  */
+#define YYTRANSLATE(YYX)                                \
+  (0 <= (YYX) && (YYX) <= YYMAXUTOK                     \
+   ? YY_CAST (yysymbol_kind_t, yytranslate[YYX])        \
+   : YYSYMBOL_YYUNDEF)
+
+/* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
+   as returned by yylex.  */
+static const yytype_int8 yytranslate[] =
 {
        0,     3,     4,     5,     6,     7,     8,     9,    10,    11,
       12,    13,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -859,89 +953,162 @@ static const yytype_uint8 yytranslate[] =
 };
 
 #if YYDEBUG
-/* YYPRHS[YYN] -- Index of the first RHS symbol of rule number YYN in
-   YYRHS.  */
-static const yytype_uint8 yyprhs[] =
+/* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
+static const yytype_int16 yyrline[] =
 {
-       0,     0,     3,     8,    11,    14,    15,    18,    21,    24,
-      28,    31,    35,    39,    43,    47,    50,    53,    56,    58,
-      62,    64,    68,    70,    74,    76,    78,    80,    83,    87,
-      89,    93,    95,    99,   104,   110,   114,   116,   118,   120,
-     121,   124,   127,   130,   131,   134,   137,   140,   143,   144,
-     147,   148,   151,   153,   154,   158,   164,   165,   169,   170,
-     172,   173,   177,   178,   181,   182
-};
-
-/* YYRHS -- A `-1'-separated list of the rules' RHS.  */
-static const yytype_int8 yyrhs[] =
-{
-      35,     0,    -1,    36,    26,    52,    27,    -1,    37,    38,
-      -1,     3,    29,    -1,    -1,    38,    39,    -1,     5,    32,
-      -1,    11,    40,    -1,     6,    32,    50,    -1,     7,    58,
-      -1,    12,    30,    41,    -1,     4,    32,    44,    -1,     8,
-      29,    48,    -1,     9,    28,    56,    -1,    10,    28,    -1,
-      13,    51,    -1,    31,    49,    -1,    32,    -1,    32,    21,
-      40,    -1,    42,    -1,    41,    20,    42,    -1,    43,    -1,
-      42,    21,    43,    -1,    33,    -1,    32,    -1,    30,    -1,
-      22,    43,    -1,    14,    41,    15,    -1,    45,    -1,    44,
-      20,    45,    -1,    46,    -1,    45,    21,    46,    -1,    47,
-      14,    32,    15,    -1,    47,    14,    22,    32,    15,    -1,
-      14,    44,    15,    -1,    33,    -1,    25,    -1,    24,    -1,
-      -1,    33,    48,    -1,    32,    48,    -1,    29,    48,    -1,
-      -1,    49,    33,    -1,    49,    32,    -1,    49,    28,    -1,
-      49,    29,    -1,    -1,    28,    50,    -1,    -1,    29,    51,
-      -1,    53,    -1,    -1,    54,    59,    53,    -1,    23,    55,
-      32,    56,    57,    -1,    -1,    18,    41,    19,    -1,    -1,
-      28,    -1,    -1,    16,    58,    17,    -1,    -1,    32,    58,
-      -1,    -1,    55,    40,    57,    59,    -1
-};
-
-/* YYRLINE[YYN] -- source line where rule number YYN was defined.  */
-static const yytype_uint16 yyrline[] =
-{
-       0,   449,   449,   457,   459,   468,   469,   479,   483,   491,
-     496,   500,   508,   513,   522,   523,   527,   535,   538,   539,
-     542,   543,   546,   547,   550,   551,   552,   553,   554,   557,
-     558,   561,   562,   565,   566,   567,   568,   571,   572,   575,
-     576,   582,   588,   591,   592,   593,   594,   595,   597,   598,
-     601,   602,   605,   609,   610,   616,   620,   621,   624,   625,
-     628,   629,   632,   633,   636,   637
+       0,   465,   465,   473,   475,   484,   485,   495,   499,   507,
+     512,   516,   524,   529,   538,   539,   543,   551,   554,   555,
+     558,   559,   562,   563,   566,   567,   568,   569,   570,   573,
+     574,   577,   578,   581,   582,   583,   584,   587,   588,   591,
+     592,   598,   604,   607,   608,   609,   610,   611,   613,   614,
+     617,   618,   621,   625,   626,   632,   636,   637,   640,   641,
+     644,   645,   648,   649,   652,   653
 };
 #endif
 
-#if YYDEBUG || YYERROR_VERBOSE || YYTOKEN_TABLE
+/** Accessing symbol of state STATE.  */
+#define YY_ACCESSING_SYMBOL(State) YY_CAST (yysymbol_kind_t, yystos[State])
+
+#if YYDEBUG || 0
+/* The user-facing name of the symbol whose (internal) number is
+   YYSYMBOL.  No bounds checking.  */
+static const char *yysymbol_name (yysymbol_kind_t yysymbol) YY_ATTRIBUTE_UNUSED;
+
 /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
 {
-  "$end", "error", "$undefined", "HOAHDR", "ACCEPTANCE", "STATES", "AP",
-  "CNTAP", "ACCNAME", "TOOL", "NAME", "START", "ALIAS", "PROPERTIES",
-  "\"(\"", "\")\"", "\"{\"", "\"}\"", "\"[\"", "\"]\"", "\"|\"", "\"&\"",
-  "\"!\"", "STATEHDR", "INF", "FIN", "BEGINBODY", "ENDBODY", "STRING",
-  "IDENTIFIER", "ANAME", "HEADERNAME", "INT", "BOOL", "$accept",
-  "automaton", "header", "format_version", "header_list", "header_item",
-  "state_conj", "label_expr", "lab_exp_conj", "lab_exp_atom",
-  "acceptance_cond", "acc_cond_conj", "acc_cond_atom", "accid",
-  "boolintid_list", "boolintstrid_list", "string_list", "id_list", "body",
-  "statespec_list", "state_name", "maybe_label", "maybe_string",
-  "maybe_accsig", "int_list", "trans_list", 0
+  "\"end of file\"", "error", "\"invalid token\"", "HOAHDR", "ACCEPTANCE",
+  "STATES", "AP", "CNTAP", "ACCNAME", "TOOL", "NAME", "START", "ALIAS",
+  "PROPERTIES", "\"(\"", "\")\"", "\"{\"", "\"}\"", "\"[\"", "\"]\"",
+  "\"|\"", "\"&\"", "\"!\"", "STATEHDR", "INF", "FIN", "BEGINBODY",
+  "ENDBODY", "STRING", "IDENTIFIER", "ANAME", "HEADERNAME", "INT", "BOOL",
+  "$accept", "automaton", "header", "format_version", "header_list",
+  "header_item", "state_conj", "label_expr", "lab_exp_conj",
+  "lab_exp_atom", "acceptance_cond", "acc_cond_conj", "acc_cond_atom",
+  "accid", "boolintid_list", "boolintstrid_list", "string_list", "id_list",
+  "body", "statespec_list", "state_name", "maybe_label", "maybe_string",
+  "maybe_accsig", "int_list", "trans_list", YY_NULLPTR
 };
+
+static const char *
+yysymbol_name (yysymbol_kind_t yysymbol)
+{
+  return yytname[yysymbol];
+}
 #endif
 
-# ifdef YYPRINT
-/* YYTOKNUM[YYLEX-NUM] -- Internal token number corresponding to
-   token YYLEX-NUM.  */
-static const yytype_uint16 yytoknum[] =
-{
-       0,   256,   257,     1,     2,     3,     4,     5,     6,     7,
-       8,     9,    10,    11,   258,   259,   260,   261,   262,   263,
-     264,   265,   266,   267,   268,   269,   270,   271,   272,   273,
-     274,   275,   276,   277
-};
-# endif
+#define YYPACT_NINF (-53)
 
-/* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
-static const yytype_uint8 yyr1[] =
+#define yypact_value_is_default(Yyn) \
+  ((Yyn) == YYPACT_NINF)
+
+#define YYTABLE_NINF (-57)
+
+#define yytable_value_is_error(Yyn) \
+  0
+
+/* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
+   STATE-NUM.  */
+static const yytype_int8 yypact[] =
+{
+      12,   -10,    20,    15,   -53,   -53,   -53,   -53,    -3,    23,
+       7,    -6,    24,    25,    26,    30,    32,    33,    31,    35,
+      37,   -53,   -53,   -53,    36,     4,     0,   -53,    34,    26,
+     -53,    16,    39,   -53,    47,   -53,    -1,    37,   -53,    11,
+      -1,    38,    31,   -53,     0,   -53,   -53,   -53,    49,    50,
+     -53,    41,    34,   -53,   -53,    16,    16,    16,   -53,   -53,
+     -53,    31,    -1,    -1,   -53,   -53,   -53,    52,    53,   -53,
+     -53,   -53,   -53,   -53,   -53,    27,    39,    57,     3,     0,
+       0,    -5,   -53,   -53,   -53,   -53,   -53,    22,   -53,    -1,
+      -1,   -53,    57,    26,     4,   -53,    50,   -53,    43,    61,
+     -53,    53,   -53,   -53,    60,   -53,    63,   -53,   -53,   -53
+};
+
+/* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
+   Performed when YYTABLE does not specify something else to do.  Zero
+   means the default is an error.  */
+static const yytype_int8 yydefact[] =
+{
+       0,     0,     0,     0,     5,     4,     1,    53,     3,     0,
+      52,     0,     0,     0,    62,     0,     0,     0,     0,     0,
+      50,    43,     6,     2,    56,    64,     0,     7,    48,    62,
+      10,    39,    58,    15,    18,     8,     0,    50,    16,    17,
+       0,     0,     0,    54,     0,    38,    37,    36,    12,    29,
+      31,     0,    48,     9,    63,    39,    39,    39,    13,    59,
+      14,     0,     0,     0,    26,    25,    24,    11,    20,    22,
+      51,    46,    47,    45,    44,     0,    58,    60,     0,     0,
+       0,     0,    49,    42,    41,    40,    19,     0,    27,     0,
+       0,    57,    60,    62,    64,    35,    30,    32,     0,     0,
+      28,    21,    23,    55,     0,    65,     0,    33,    61,    34
+};
+
+/* YYPGOTO[NTERM-NUM].  */
+static const yytype_int8 yypgoto[] =
+{
+     -53,   -53,   -53,   -53,   -53,   -53,   -26,   -28,    -9,   -52,
+      40,     2,     5,   -53,    -4,   -53,    42,    45,   -53,   -53,
+     -53,    55,    10,    -2,   -29,   -11
+};
+
+/* YYDEFGOTO[NTERM-NUM].  */
+static const yytype_int8 yydefgoto[] =
+{
+       0,     2,     3,     4,     8,    22,    35,    67,    68,    69,
+      48,    49,    50,    51,    58,    39,    53,    38,     9,    10,
+      25,    42,    60,    94,    30,    43
+};
+
+/* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
+   positive, shift that token.  If negative, reduce the rule whose
+   number is the opposite.  If YYTABLE_NINF, syntax error.  */
+static const yytype_int8 yytable[] =
+{
+      54,    11,    12,    13,    14,    15,    16,    17,    18,    19,
+      20,    88,    75,    62,    44,     1,    77,    98,    95,     5,
+       6,    63,    40,    79,    45,    46,    26,    99,    21,    64,
+      24,    65,    66,    47,    87,    86,   -56,   100,   102,    71,
+      72,     7,    89,    73,    74,    55,    91,    89,    56,    57,
+      23,    83,    84,    85,    40,    81,    27,    28,    29,    31,
+      32,    33,    52,    34,   104,    36,    37,    59,    61,    79,
+      76,    80,    89,    93,    90,   106,   107,   108,   109,    41,
+     101,    96,    70,   105,    78,    97,    92,     0,     0,     0,
+     103,     0,     0,     0,    82
+};
+
+static const yytype_int8 yycheck[] =
+{
+      29,     4,     5,     6,     7,     8,     9,    10,    11,    12,
+      13,    63,    40,    14,    14,     3,    42,    22,    15,    29,
+       0,    22,    18,    20,    24,    25,    32,    32,    31,    30,
+      23,    32,    33,    33,    62,    61,    32,    15,    90,    28,
+      29,    26,    20,    32,    33,    29,    19,    20,    32,    33,
+      27,    55,    56,    57,    18,    14,    32,    32,    32,    29,
+      28,    28,    28,    32,    93,    30,    29,    28,    21,    20,
+      32,    21,    20,    16,    21,    32,    15,    17,    15,    24,
+      89,    79,    37,    94,    44,    80,    76,    -1,    -1,    -1,
+      92,    -1,    -1,    -1,    52
+};
+
+/* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
+   state STATE-NUM.  */
+static const yytype_int8 yystos[] =
+{
+       0,     3,    35,    36,    37,    29,     0,    26,    38,    52,
+      53,     4,     5,     6,     7,     8,     9,    10,    11,    12,
+      13,    31,    39,    27,    23,    54,    32,    32,    32,    32,
+      58,    29,    28,    28,    32,    40,    30,    29,    51,    49,
+      18,    55,    55,    59,    14,    24,    25,    33,    44,    45,
+      46,    47,    28,    50,    58,    29,    32,    33,    48,    28,
+      56,    21,    14,    22,    30,    32,    33,    41,    42,    43,
+      51,    28,    29,    32,    33,    41,    32,    40,    44,    20,
+      21,    14,    50,    48,    48,    48,    40,    41,    43,    20,
+      21,    19,    56,    16,    57,    15,    45,    46,    22,    32,
+      15,    42,    43,    57,    58,    59,    32,    15,    17,    15
+};
+
+/* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
+static const yytype_int8 yyr1[] =
 {
        0,    34,    35,    36,    37,    38,    38,    39,    39,    39,
       39,    39,    39,    39,    39,    39,    39,    39,    40,    40,
@@ -952,8 +1119,8 @@ static const yytype_uint8 yyr1[] =
       57,    57,    58,    58,    59,    59
 };
 
-/* YYR2[YYN] -- Number of symbols composing right hand side of rule YYN.  */
-static const yytype_uint8 yyr2[] =
+/* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
+static const yytype_int8 yyr2[] =
 {
        0,     2,     4,     2,     2,     0,     2,     2,     2,     3,
        2,     3,     3,     3,     3,     2,     2,     2,     1,     3,
@@ -964,200 +1131,67 @@ static const yytype_uint8 yyr2[] =
        0,     3,     0,     2,     0,     4
 };
 
-/* YYDEFACT[STATE-NAME] -- Default rule to reduce with in state
-   STATE-NUM when YYTABLE doesn't specify something else to do.  Zero
-   means the default is an error.  */
-static const yytype_uint8 yydefact[] =
-{
-       0,     0,     0,     0,     5,     4,     1,    53,     3,    56,
-       0,    52,    64,     0,     0,     0,    62,     0,     0,     0,
-       0,     0,    50,    43,     6,     0,     0,     2,     0,    53,
-       0,     7,    48,    62,    10,    39,    58,    15,    18,     8,
-       0,    50,    16,    17,     0,     0,    26,    25,    24,     0,
-      20,    22,    58,    60,    54,     0,    38,    37,    36,    12,
-      29,    31,     0,    48,     9,    63,    39,    39,    39,    13,
-      59,    14,     0,    11,    51,    46,    47,    45,    44,     0,
-      27,    57,     0,     0,    60,    62,    64,     0,     0,     0,
-       0,    49,    42,    41,    40,    19,    28,    21,    23,    55,
-       0,    65,    35,    30,    32,     0,     0,    61,     0,    33,
-      34
-};
 
-/* YYDEFGOTO[NTERM-NUM].  */
-static const yytype_int8 yydefgoto[] =
-{
-      -1,     2,     3,     4,     8,    24,    39,    49,    50,    51,
-      59,    60,    61,    62,    69,    43,    64,    42,    10,    11,
-      12,    28,    71,    86,    34,    29
-};
+enum { YYENOMEM = -2 };
 
-/* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
-   STATE-NUM.  */
-#define YYPACT_NINF -44
-static const yytype_int8 yypact[] =
-{
-      10,    -5,    36,    13,   -44,   -44,   -44,    21,    -1,    28,
-      24,   -44,    -4,    23,    25,    26,    27,    31,    33,    35,
-      30,    37,    39,   -44,   -44,     1,    32,   -44,    30,    21,
-       2,   -44,    38,    27,   -44,     9,    41,   -44,    44,   -44,
-       1,    39,   -44,   -11,     1,     1,   -44,   -44,   -44,    34,
-      49,   -44,    41,    40,   -44,     2,   -44,   -44,   -44,    51,
-      52,   -44,    58,    38,   -44,   -44,     9,     9,     9,   -44,
-     -44,   -44,    30,    54,   -44,   -44,   -44,   -44,   -44,     5,
-     -44,   -44,     1,     1,    40,    27,    -4,    17,     2,     2,
-      -3,   -44,   -44,   -44,   -44,   -44,   -44,    49,   -44,   -44,
-      59,   -44,   -44,    52,   -44,    43,    62,   -44,    63,   -44,
-     -44
-};
+#define yyerrok         (yyerrstatus = 0)
+#define yyclearin       (yychar = YYEMPTY)
 
-/* YYPGOTO[NTERM-NUM].  */
-static const yytype_int8 yypgoto[] =
-{
-     -44,   -44,   -44,   -44,   -44,   -44,   -27,     3,    -2,   -43,
-      29,    -9,    -8,   -44,   -18,   -44,    19,    42,   -44,    56,
-     -44,    77,    45,     4,   -33,     6
-};
+#define YYACCEPT        goto yyacceptlab
+#define YYABORT         goto yyabortlab
+#define YYERROR         goto yyerrorlab
+#define YYNOMEM         goto yyexhaustedlab
 
-/* YYTABLE[YYPACT[STATE-NUM]].  What to do in state STATE-NUM.  If
-   positive, shift that token.  If negative, reduce the rule which
-   number is the opposite.  If zero, do what YYDEFACT says.
-   If YYTABLE_NINF, syntax error.  */
-#define YYTABLE_NINF -57
-static const yytype_int8 yytable[] =
-{
-      65,    53,    80,    13,    14,    15,    16,    17,    18,    19,
-      20,    21,    22,     1,    25,    44,    55,    75,    76,   105,
-      96,    77,    78,    45,     5,    82,    56,    57,   -56,   106,
-      23,    46,   102,    47,    48,    58,     6,    88,    66,     7,
-      98,    67,    68,    73,     9,    95,    25,    79,    92,    93,
-      94,    27,   100,    81,    82,    30,    85,    31,    32,    33,
-      35,    36,    38,    37,    52,    72,    63,    40,    41,    70,
-      83,    88,    90,    89,    82,   108,   107,   109,   110,   103,
-      97,   104,    91,    74,    87,    54,    26,     0,    99,     0,
-       0,     0,   101,     0,     0,     0,     0,    84
-};
-
-static const yytype_int8 yycheck[] =
-{
-      33,    28,    45,     4,     5,     6,     7,     8,     9,    10,
-      11,    12,    13,     3,    18,    14,    14,    28,    29,    22,
-      15,    32,    33,    22,    29,    20,    24,    25,    32,    32,
-      31,    30,    15,    32,    33,    33,     0,    20,    29,    26,
-      83,    32,    33,    40,    23,    72,    18,    44,    66,    67,
-      68,    27,    85,    19,    20,    32,    16,    32,    32,    32,
-      29,    28,    32,    28,    32,    21,    28,    30,    29,    28,
-      21,    20,    14,    21,    20,    32,    17,    15,    15,    88,
-      82,    89,    63,    41,    55,    29,     9,    -1,    84,    -1,
-      -1,    -1,    86,    -1,    -1,    -1,    -1,    52
-};
-
-/* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
-   symbol of state STATE-NUM.  */
-static const yytype_uint8 yystos[] =
-{
-       0,     3,    35,    36,    37,    29,     0,    26,    38,    23,
-      52,    53,    54,     4,     5,     6,     7,     8,     9,    10,
-      11,    12,    13,    31,    39,    18,    55,    27,    55,    59,
-      32,    32,    32,    32,    58,    29,    28,    28,    32,    40,
-      30,    29,    51,    49,    14,    22,    30,    32,    33,    41,
-      42,    43,    32,    40,    53,    14,    24,    25,    33,    44,
-      45,    46,    47,    28,    50,    58,    29,    32,    33,    48,
-      28,    56,    21,    41,    51,    28,    29,    32,    33,    41,
-      43,    19,    20,    21,    56,    16,    57,    44,    20,    21,
-      14,    50,    48,    48,    48,    40,    15,    42,    43,    57,
-      58,    59,    15,    45,    46,    22,    32,    17,    32,    15,
-      15
-};
-
-#define yyerrok		(yyerrstatus = 0)
-#define yyclearin	(yychar = YYEMPTY)
-#define YYEMPTY		(-2)
-#define YYEOF		0
-
-#define YYACCEPT	goto yyacceptlab
-#define YYABORT		goto yyabortlab
-#define YYERROR		goto yyerrorlab
-
-
-/* Like YYERROR except do call yyerror.  This remains here temporarily
-   to ease the transition to the new meaning of YYERROR, for GCC.
-   Once GCC version 2 has supplanted version 1, this can go.  */
-
-#define YYFAIL		goto yyerrlab
 
 #define YYRECOVERING()  (!!yyerrstatus)
 
-#define YYBACKUP(Token, Value)					\
-do								\
-  if (yychar == YYEMPTY && yylen == 1)				\
-    {								\
-      yychar = (Token);						\
-      yylval = (Value);						\
-      yytoken = YYTRANSLATE (yychar);				\
-      YYPOPSTACK (1);						\
-      goto yybackup;						\
-    }								\
-  else								\
-    {								\
-      yyerror (YY_("syntax error: cannot back up")); \
-      YYERROR;							\
-    }								\
-while (YYID (0))
+#define YYBACKUP(Token, Value)                                    \
+  do                                                              \
+    if (yychar == YYEMPTY)                                        \
+      {                                                           \
+        yychar = (Token);                                         \
+        yylval = (Value);                                         \
+        YYPOPSTACK (yylen);                                       \
+        yystate = *yyssp;                                         \
+        goto yybackup;                                            \
+      }                                                           \
+    else                                                          \
+      {                                                           \
+        yyerror (YY_("syntax error: cannot back up")); \
+        YYERROR;                                                  \
+      }                                                           \
+  while (0)
 
-
-#define YYTERROR	1
-#define YYERRCODE	256
-
+/* Backward compatibility with an undocumented macro.
+   Use YYerror or YYUNDEF. */
+#define YYERRCODE YYUNDEF
 
 /* YYLLOC_DEFAULT -- Set CURRENT to span from RHS[1] to RHS[N].
    If N is 0, then set CURRENT to the empty location which ends
    the previous symbol: RHS[0] (always defined).  */
 
-#define YYRHSLOC(Rhs, K) ((Rhs)[K])
 #ifndef YYLLOC_DEFAULT
-# define YYLLOC_DEFAULT(Current, Rhs, N)				\
-    do									\
-      if (YYID (N))                                                    \
-	{								\
-	  (Current).first_line   = YYRHSLOC (Rhs, 1).first_line;	\
-	  (Current).first_column = YYRHSLOC (Rhs, 1).first_column;	\
-	  (Current).last_line    = YYRHSLOC (Rhs, N).last_line;		\
-	  (Current).last_column  = YYRHSLOC (Rhs, N).last_column;	\
-	}								\
-      else								\
-	{								\
-	  (Current).first_line   = (Current).last_line   =		\
-	    YYRHSLOC (Rhs, 0).last_line;				\
-	  (Current).first_column = (Current).last_column =		\
-	    YYRHSLOC (Rhs, 0).last_column;				\
-	}								\
-    while (YYID (0))
+# define YYLLOC_DEFAULT(Current, Rhs, N)                                \
+    do                                                                  \
+      if (N)                                                            \
+        {                                                               \
+          (Current).first_line   = YYRHSLOC (Rhs, 1).first_line;        \
+          (Current).first_column = YYRHSLOC (Rhs, 1).first_column;      \
+          (Current).last_line    = YYRHSLOC (Rhs, N).last_line;         \
+          (Current).last_column  = YYRHSLOC (Rhs, N).last_column;       \
+        }                                                               \
+      else                                                              \
+        {                                                               \
+          (Current).first_line   = (Current).last_line   =              \
+            YYRHSLOC (Rhs, 0).last_line;                                \
+          (Current).first_column = (Current).last_column =              \
+            YYRHSLOC (Rhs, 0).last_column;                              \
+        }                                                               \
+    while (0)
 #endif
 
+#define YYRHSLOC(Rhs, K) ((Rhs)[K])
 
-/* YY_LOCATION_PRINT -- Print the location on the stream.
-   This macro was not mandated originally: define only if we know
-   we won't break user code: when these are the locations we know.  */
-
-#ifndef YY_LOCATION_PRINT
-# if defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL
-#  define YY_LOCATION_PRINT(File, Loc)			\
-     fprintf (File, "%d.%d-%d.%d",			\
-	      (Loc).first_line, (Loc).first_column,	\
-	      (Loc).last_line,  (Loc).last_column)
-# else
-#  define YY_LOCATION_PRINT(File, Loc) ((void) 0)
-# endif
-#endif
-
-
-/* YYLEX -- calling `yylex' with the right arguments.  */
-
-#ifdef YYLEX_PARAM
-# define YYLEX yylex (YYLEX_PARAM)
-#else
-# define YYLEX yylex ()
-#endif
 
 /* Enable debugging if requested.  */
 #if YYDEBUG
@@ -1167,85 +1201,118 @@ while (YYID (0))
 #  define YYFPRINTF fprintf
 # endif
 
-# define YYDPRINTF(Args)			\
-do {						\
-  if (yydebug)					\
-    YYFPRINTF Args;				\
-} while (YYID (0))
-
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)			  \
-do {									  \
-  if (yydebug)								  \
-    {									  \
-      YYFPRINTF (stderr, "%s ", Title);					  \
-      yy_symbol_print (stderr,						  \
-		  Type, Value, Location); \
-      YYFPRINTF (stderr, "\n");						  \
-    }									  \
-} while (YYID (0))
+# define YYDPRINTF(Args)                        \
+do {                                            \
+  if (yydebug)                                  \
+    YYFPRINTF Args;                             \
+} while (0)
 
 
-/*--------------------------------.
-| Print this symbol on YYOUTPUT.  |
-`--------------------------------*/
+/* YYLOCATION_PRINT -- Print the location on the stream.
+   This macro was not mandated originally: define only if we know
+   we won't break user code: when these are the locations we know.  */
 
-/*ARGSUSED*/
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-static void
-yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp)
-#else
-static void
-yy_symbol_value_print (yyoutput, yytype, yyvaluep, yylocationp)
-    FILE *yyoutput;
-    int yytype;
-    YYSTYPE const * const yyvaluep;
-    YYLTYPE const * const yylocationp;
-#endif
+# ifndef YYLOCATION_PRINT
+
+#  if defined YY_LOCATION_PRINT
+
+   /* Temporary convenience wrapper in case some people defined the
+      undocumented and private YY_LOCATION_PRINT macros.  */
+#   define YYLOCATION_PRINT(File, Loc)  YY_LOCATION_PRINT(File, *(Loc))
+
+#  elif defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL
+
+/* Print *YYLOCP on YYO.  Private, do not rely on its existence. */
+
+YY_ATTRIBUTE_UNUSED
+static int
+yy_location_print_ (FILE *yyo, YYLTYPE const * const yylocp)
 {
+  int res = 0;
+  int end_col = 0 != yylocp->last_column ? yylocp->last_column - 1 : 0;
+  if (0 <= yylocp->first_line)
+    {
+      res += YYFPRINTF (yyo, "%d", yylocp->first_line);
+      if (0 <= yylocp->first_column)
+        res += YYFPRINTF (yyo, ".%d", yylocp->first_column);
+    }
+  if (0 <= yylocp->last_line)
+    {
+      if (yylocp->first_line < yylocp->last_line)
+        {
+          res += YYFPRINTF (yyo, "-%d", yylocp->last_line);
+          if (0 <= end_col)
+            res += YYFPRINTF (yyo, ".%d", end_col);
+        }
+      else if (0 <= end_col && yylocp->first_column < end_col)
+        res += YYFPRINTF (yyo, "-%d", end_col);
+    }
+  return res;
+}
+
+#   define YYLOCATION_PRINT  yy_location_print_
+
+    /* Temporary convenience wrapper in case some people defined the
+       undocumented and private YY_LOCATION_PRINT macros.  */
+#   define YY_LOCATION_PRINT(File, Loc)  YYLOCATION_PRINT(File, &(Loc))
+
+#  else
+
+#   define YYLOCATION_PRINT(File, Loc) ((void) 0)
+    /* Temporary convenience wrapper in case some people defined the
+       undocumented and private YY_LOCATION_PRINT macros.  */
+#   define YY_LOCATION_PRINT  YYLOCATION_PRINT
+
+#  endif
+# endif /* !defined YYLOCATION_PRINT */
+
+
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)                    \
+do {                                                                      \
+  if (yydebug)                                                            \
+    {                                                                     \
+      YYFPRINTF (stderr, "%s ", Title);                                   \
+      yy_symbol_print (stderr,                                            \
+                  Kind, Value, Location); \
+      YYFPRINTF (stderr, "\n");                                           \
+    }                                                                     \
+} while (0)
+
+
+/*-----------------------------------.
+| Print this symbol's value on YYO.  |
+`-----------------------------------*/
+
+static void
+yy_symbol_value_print (FILE *yyo,
+                       yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp)
+{
+  FILE *yyoutput = yyo;
+  YY_USE (yyoutput);
+  YY_USE (yylocationp);
   if (!yyvaluep)
     return;
-  YYUSE (yylocationp);
-# ifdef YYPRINT
-  if (yytype < YYNTOKENS)
-    YYPRINT (yyoutput, yytoknum[yytype], *yyvaluep);
-# else
-  YYUSE (yyoutput);
-# endif
-  switch (yytype)
-    {
-      default:
-	break;
-    }
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+  YY_USE (yykind);
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
 
-/*--------------------------------.
-| Print this symbol on YYOUTPUT.  |
-`--------------------------------*/
+/*---------------------------.
+| Print this symbol on YYO.  |
+`---------------------------*/
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
-yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp)
-#else
-static void
-yy_symbol_print (yyoutput, yytype, yyvaluep, yylocationp)
-    FILE *yyoutput;
-    int yytype;
-    YYSTYPE const * const yyvaluep;
-    YYLTYPE const * const yylocationp;
-#endif
+yy_symbol_print (FILE *yyo,
+                 yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp)
 {
-  if (yytype < YYNTOKENS)
-    YYFPRINTF (yyoutput, "token %s (", yytname[yytype]);
-  else
-    YYFPRINTF (yyoutput, "nterm %s (", yytname[yytype]);
+  YYFPRINTF (yyo, "%s %s (",
+             yykind < YYNTOKENS ? "token" : "nterm", yysymbol_name (yykind));
 
-  YY_LOCATION_PRINT (yyoutput, *yylocationp);
-  YYFPRINTF (yyoutput, ": ");
-  yy_symbol_value_print (yyoutput, yytype, yyvaluep, yylocationp);
-  YYFPRINTF (yyoutput, ")");
+  YYLOCATION_PRINT (yyo, yylocationp);
+  YYFPRINTF (yyo, ": ");
+  yy_symbol_value_print (yyo, yykind, yyvaluep, yylocationp);
+  YYFPRINTF (yyo, ")");
 }
 
 /*------------------------------------------------------------------.
@@ -1253,81 +1320,69 @@ yy_symbol_print (yyoutput, yytype, yyvaluep, yylocationp)
 | TOP (included).                                                   |
 `------------------------------------------------------------------*/
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
-yy_stack_print (yytype_int16 *bottom, yytype_int16 *top)
-#else
-static void
-yy_stack_print (bottom, top)
-    yytype_int16 *bottom;
-    yytype_int16 *top;
-#endif
+yy_stack_print (yy_state_t *yybottom, yy_state_t *yytop)
 {
   YYFPRINTF (stderr, "Stack now");
-  for (; bottom <= top; ++bottom)
-    YYFPRINTF (stderr, " %d", *bottom);
+  for (; yybottom <= yytop; yybottom++)
+    {
+      int yybot = *yybottom;
+      YYFPRINTF (stderr, " %d", yybot);
+    }
   YYFPRINTF (stderr, "\n");
 }
 
-# define YY_STACK_PRINT(Bottom, Top)				\
-do {								\
-  if (yydebug)							\
-    yy_stack_print ((Bottom), (Top));				\
-} while (YYID (0))
+# define YY_STACK_PRINT(Bottom, Top)                            \
+do {                                                            \
+  if (yydebug)                                                  \
+    yy_stack_print ((Bottom), (Top));                           \
+} while (0)
 
 
 /*------------------------------------------------.
 | Report that the YYRULE is going to be reduced.  |
 `------------------------------------------------*/
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
-yy_reduce_print (YYSTYPE *yyvsp, YYLTYPE *yylsp, int yyrule)
-#else
-static void
-yy_reduce_print (yyvsp, yylsp, yyrule)
-    YYSTYPE *yyvsp;
-    YYLTYPE *yylsp;
-    int yyrule;
-#endif
+yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp,
+                 int yyrule)
 {
+  int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
   int yyi;
-  unsigned long int yylno = yyrline[yyrule];
-  YYFPRINTF (stderr, "Reducing stack by rule %d (line %lu):\n",
-	     yyrule - 1, yylno);
+  YYFPRINTF (stderr, "Reducing stack by rule %d (line %d):\n",
+             yyrule - 1, yylno);
   /* The symbols being reduced.  */
   for (yyi = 0; yyi < yynrhs; yyi++)
     {
-      fprintf (stderr, "   $%d = ", yyi + 1);
-      yy_symbol_print (stderr, yyrhs[yyprhs[yyrule] + yyi],
-		       &(yyvsp[(yyi + 1) - (yynrhs)])
-		       , &(yylsp[(yyi + 1) - (yynrhs)])		       );
-      fprintf (stderr, "\n");
+      YYFPRINTF (stderr, "   $%d = ", yyi + 1);
+      yy_symbol_print (stderr,
+                       YY_ACCESSING_SYMBOL (+yyssp[yyi + 1 - yynrhs]),
+                       &yyvsp[(yyi + 1) - (yynrhs)],
+                       &(yylsp[(yyi + 1) - (yynrhs)]));
+      YYFPRINTF (stderr, "\n");
     }
 }
 
-# define YY_REDUCE_PRINT(Rule)		\
-do {					\
-  if (yydebug)				\
-    yy_reduce_print (yyvsp, yylsp, Rule); \
-} while (YYID (0))
+# define YY_REDUCE_PRINT(Rule)          \
+do {                                    \
+  if (yydebug)                          \
+    yy_reduce_print (yyssp, yyvsp, yylsp, Rule); \
+} while (0)
 
 /* Nonzero means print parse trace.  It is left uninitialized so that
    multiple parsers can coexist.  */
 int yydebug;
 #else /* !YYDEBUG */
-# define YYDPRINTF(Args)
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)
+# define YYDPRINTF(Args) ((void) 0)
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)
 # define YY_STACK_PRINT(Bottom, Top)
 # define YY_REDUCE_PRINT(Rule)
 #endif /* !YYDEBUG */
 
 
 /* YYINITDEPTH -- initial size of the parser's stacks.  */
-#ifndef	YYINITDEPTH
+#ifndef YYINITDEPTH
 # define YYINITDEPTH 200
 #endif
 
@@ -1342,281 +1397,45 @@ int yydebug;
 # define YYMAXDEPTH 10000
 #endif
 
-
 
-#if YYERROR_VERBOSE
 
-# ifndef yystrlen
-#  if defined __GLIBC__ && defined _STRING_H
-#   define yystrlen strlen
-#  else
-/* Return the length of YYSTR.  */
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-static YYSIZE_T
-yystrlen (const char *yystr)
-#else
-static YYSIZE_T
-yystrlen (yystr)
-    const char *yystr;
-#endif
-{
-  YYSIZE_T yylen;
-  for (yylen = 0; yystr[yylen]; yylen++)
-    continue;
-  return yylen;
-}
-#  endif
-# endif
 
-# ifndef yystpcpy
-#  if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
-#   define yystpcpy stpcpy
-#  else
-/* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in
-   YYDEST.  */
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-static char *
-yystpcpy (char *yydest, const char *yysrc)
-#else
-static char *
-yystpcpy (yydest, yysrc)
-    char *yydest;
-    const char *yysrc;
-#endif
-{
-  char *yyd = yydest;
-  const char *yys = yysrc;
 
-  while ((*yyd++ = *yys++) != '\0')
-    continue;
-
-  return yyd - 1;
-}
-#  endif
-# endif
-
-# ifndef yytnamerr
-/* Copy to YYRES the contents of YYSTR after stripping away unnecessary
-   quotes and backslashes, so that it's suitable for yyerror.  The
-   heuristic is that double-quoting is unnecessary unless the string
-   contains an apostrophe, a comma, or backslash (other than
-   backslash-backslash).  YYSTR is taken from yytname.  If YYRES is
-   null, do not copy; instead, return the length of what the result
-   would have been.  */
-static YYSIZE_T
-yytnamerr (char *yyres, const char *yystr)
-{
-  if (*yystr == '"')
-    {
-      YYSIZE_T yyn = 0;
-      char const *yyp = yystr;
-
-      for (;;)
-	switch (*++yyp)
-	  {
-	  case '\'':
-	  case ',':
-	    goto do_not_strip_quotes;
-
-	  case '\\':
-	    if (*++yyp != '\\')
-	      goto do_not_strip_quotes;
-	    /* Fall through.  */
-	  default:
-	    if (yyres)
-	      yyres[yyn] = *yyp;
-	    yyn++;
-	    break;
-
-	  case '"':
-	    if (yyres)
-	      yyres[yyn] = '\0';
-	    return yyn;
-	  }
-    do_not_strip_quotes: ;
-    }
-
-  if (! yyres)
-    return yystrlen (yystr);
-
-  return yystpcpy (yyres, yystr) - yyres;
-}
-# endif
-
-/* Copy into YYRESULT an error message about the unexpected token
-   YYCHAR while in state YYSTATE.  Return the number of bytes copied,
-   including the terminating null byte.  If YYRESULT is null, do not
-   copy anything; just return the number of bytes that would be
-   copied.  As a special case, return 0 if an ordinary "syntax error"
-   message will do.  Return YYSIZE_MAXIMUM if overflow occurs during
-   size calculation.  */
-static YYSIZE_T
-yysyntax_error (char *yyresult, int yystate, int yychar)
-{
-  int yyn = yypact[yystate];
-
-  if (! (YYPACT_NINF < yyn && yyn <= YYLAST))
-    return 0;
-  else
-    {
-      int yytype = YYTRANSLATE (yychar);
-      YYSIZE_T yysize0 = yytnamerr (0, yytname[yytype]);
-      YYSIZE_T yysize = yysize0;
-      YYSIZE_T yysize1;
-      int yysize_overflow = 0;
-      enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
-      char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
-      int yyx;
-
-# if 0
-      /* This is so xgettext sees the translatable formats that are
-	 constructed on the fly.  */
-      YY_("syntax error, unexpected %s");
-      YY_("syntax error, unexpected %s, expecting %s");
-      YY_("syntax error, unexpected %s, expecting %s or %s");
-      YY_("syntax error, unexpected %s, expecting %s or %s or %s");
-      YY_("syntax error, unexpected %s, expecting %s or %s or %s or %s");
-# endif
-      char *yyfmt;
-      char const *yyf;
-      static char const yyunexpected[] = "syntax error, unexpected %s";
-      static char const yyexpecting[] = ", expecting %s";
-      static char const yyor[] = " or %s";
-      char yyformat[sizeof yyunexpected
-		    + sizeof yyexpecting - 1
-		    + ((YYERROR_VERBOSE_ARGS_MAXIMUM - 2)
-		       * (sizeof yyor - 1))];
-      char const *yyprefix = yyexpecting;
-
-      /* Start YYX at -YYN if negative to avoid negative indexes in
-	 YYCHECK.  */
-      int yyxbegin = yyn < 0 ? -yyn : 0;
-
-      /* Stay within bounds of both yycheck and yytname.  */
-      int yychecklim = YYLAST - yyn + 1;
-      int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
-      int yycount = 1;
-
-      yyarg[0] = yytname[yytype];
-      yyfmt = yystpcpy (yyformat, yyunexpected);
-
-      for (yyx = yyxbegin; yyx < yyxend; ++yyx)
-	if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR)
-	  {
-	    if (yycount == YYERROR_VERBOSE_ARGS_MAXIMUM)
-	      {
-		yycount = 1;
-		yysize = yysize0;
-		yyformat[sizeof yyunexpected - 1] = '\0';
-		break;
-	      }
-	    yyarg[yycount++] = yytname[yyx];
-	    yysize1 = yysize + yytnamerr (0, yytname[yyx]);
-	    yysize_overflow |= (yysize1 < yysize);
-	    yysize = yysize1;
-	    yyfmt = yystpcpy (yyfmt, yyprefix);
-	    yyprefix = yyor;
-	  }
-
-      yyf = YY_(yyformat);
-      yysize1 = yysize + yystrlen (yyf);
-      yysize_overflow |= (yysize1 < yysize);
-      yysize = yysize1;
-
-      if (yysize_overflow)
-	return YYSIZE_MAXIMUM;
-
-      if (yyresult)
-	{
-	  /* Avoid sprintf, as that infringes on the user's name space.
-	     Don't have undefined behavior even if the translation
-	     produced a string with the wrong number of "%s"s.  */
-	  char *yyp = yyresult;
-	  int yyi = 0;
-	  while ((*yyp = *yyf) != '\0')
-	    {
-	      if (*yyp == '%' && yyf[1] == 's' && yyi < yycount)
-		{
-		  yyp += yytnamerr (yyp, yyarg[yyi++]);
-		  yyf += 2;
-		}
-	      else
-		{
-		  yyp++;
-		  yyf++;
-		}
-	    }
-	}
-      return yysize;
-    }
-}
-#endif /* YYERROR_VERBOSE */
-
 
 /*-----------------------------------------------.
 | Release the memory associated to this symbol.  |
 `-----------------------------------------------*/
 
-/*ARGSUSED*/
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
-yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocationp)
-#else
-static void
-yydestruct (yymsg, yytype, yyvaluep, yylocationp)
-    const char *yymsg;
-    int yytype;
-    YYSTYPE *yyvaluep;
-    YYLTYPE *yylocationp;
-#endif
+yydestruct (const char *yymsg,
+            yysymbol_kind_t yykind, YYSTYPE *yyvaluep, YYLTYPE *yylocationp)
 {
-  YYUSE (yyvaluep);
-  YYUSE (yylocationp);
-
+  YY_USE (yyvaluep);
+  YY_USE (yylocationp);
   if (!yymsg)
     yymsg = "Deleting";
-  YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
+  YY_SYMBOL_PRINT (yymsg, yykind, yyvaluep, yylocationp);
 
-  switch (yytype)
-    {
-
-      default:
-	break;
-    }
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+  YY_USE (yykind);
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
-
-
-/* Prevent warnings from -Wmissing-prototypes.  */
-
-#ifdef YYPARSE_PARAM
-#if defined __STDC__ || defined __cplusplus
-int yyparse (void *YYPARSE_PARAM);
-#else
-int yyparse ();
-#endif
-#else /* ! YYPARSE_PARAM */
-#if defined __STDC__ || defined __cplusplus
-int yyparse (void);
-#else
-int yyparse ();
-#endif
-#endif /* ! YYPARSE_PARAM */
 
 
-
-/* The look-ahead symbol.  */
+/* Lookahead token kind.  */
 int yychar;
 
-/* The semantic value of the look-ahead symbol.  */
+/* The semantic value of the lookahead symbol.  */
 YYSTYPE yylval;
-
+/* Location data for the lookahead symbol.  */
+YYLTYPE yylloc
+# if defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL
+  = { 1, 1, 1, 1 }
+# endif
+;
 /* Number of syntax errors so far.  */
 int yynerrs;
-/* Location data for the look-ahead symbol.  */
-YYLTYPE yylloc;
+
 
 
 
@@ -1624,76 +1443,50 @@ YYLTYPE yylloc;
 | yyparse.  |
 `----------*/
 
-#ifdef YYPARSE_PARAM
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-int
-yyparse (void *YYPARSE_PARAM)
-#else
-int
-yyparse (YYPARSE_PARAM)
-    void *YYPARSE_PARAM;
-#endif
-#else /* ! YYPARSE_PARAM */
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 int
 yyparse (void)
-#else
-int
-yyparse ()
-
-#endif
-#endif
 {
-  
-  int yystate;
+    yy_state_fast_t yystate = 0;
+    /* Number of tokens to shift before error messages enabled.  */
+    int yyerrstatus = 0;
+
+    /* Refer to the stacks through separate pointers, to allow yyoverflow
+       to reallocate them elsewhere.  */
+
+    /* Their size.  */
+    YYPTRDIFF_T yystacksize = YYINITDEPTH;
+
+    /* The state stack: array, bottom, top.  */
+    yy_state_t yyssa[YYINITDEPTH];
+    yy_state_t *yyss = yyssa;
+    yy_state_t *yyssp = yyss;
+
+    /* The semantic value stack: array, bottom, top.  */
+    YYSTYPE yyvsa[YYINITDEPTH];
+    YYSTYPE *yyvs = yyvsa;
+    YYSTYPE *yyvsp = yyvs;
+
+    /* The location stack: array, bottom, top.  */
+    YYLTYPE yylsa[YYINITDEPTH];
+    YYLTYPE *yyls = yylsa;
+    YYLTYPE *yylsp = yyls;
+
   int yyn;
+  /* The return value of yyparse.  */
   int yyresult;
-  /* Number of tokens to shift before error messages enabled.  */
-  int yyerrstatus;
-  /* Look-ahead token as an internal (translated) token number.  */
-  int yytoken = 0;
-#if YYERROR_VERBOSE
-  /* Buffer for error messages, and its allocated size.  */
-  char yymsgbuf[128];
-  char *yymsg = yymsgbuf;
-  YYSIZE_T yymsg_alloc = sizeof yymsgbuf;
-#endif
-
-  /* Three stacks and their tools:
-     `yyss': related to states,
-     `yyvs': related to semantic values,
-     `yyls': related to locations.
-
-     Refer to the stacks thru separate pointers, to allow yyoverflow
-     to reallocate them elsewhere.  */
-
-  /* The state stack.  */
-  yytype_int16 yyssa[YYINITDEPTH];
-  yytype_int16 *yyss = yyssa;
-  yytype_int16 *yyssp;
-
-  /* The semantic value stack.  */
-  YYSTYPE yyvsa[YYINITDEPTH];
-  YYSTYPE *yyvs = yyvsa;
-  YYSTYPE *yyvsp;
-
-  /* The location stack.  */
-  YYLTYPE yylsa[YYINITDEPTH];
-  YYLTYPE *yyls = yylsa;
-  YYLTYPE *yylsp;
-  /* The locations where the error started and ended.  */
-  YYLTYPE yyerror_range[2];
-
-#define YYPOPSTACK(N)   (yyvsp -= (N), yyssp -= (N), yylsp -= (N))
-
-  YYSIZE_T yystacksize = YYINITDEPTH;
-
+  /* Lookahead symbol kind.  */
+  yysymbol_kind_t yytoken = YYSYMBOL_YYEMPTY;
   /* The variables used to return semantic value and location from the
      action routines.  */
   YYSTYPE yyval;
   YYLTYPE yyloc;
+
+  /* The locations where the error started and ended.  */
+  YYLTYPE yyerror_range[3];
+
+
+
+#define YYPOPSTACK(N)   (yyvsp -= (N), yyssp -= (N), yylsp -= (N))
 
   /* The number of symbols on the RHS of the reduced rule.
      Keep to zero when no symbol should be popped.  */
@@ -1701,133 +1494,144 @@ yyparse ()
 
   YYDPRINTF ((stderr, "Starting parse\n"));
 
-  yystate = 0;
-  yyerrstatus = 0;
-  yynerrs = 0;
-  yychar = YYEMPTY;		/* Cause a token to be read.  */
+  yychar = YYEMPTY; /* Cause a token to be read.  */
 
-  /* Initialize stack pointers.
-     Waste one element of value and location stack
-     so that they stay on the same level as the state stack.
-     The wasted elements are never initialized.  */
-
-  yyssp = yyss;
-  yyvsp = yyvs;
-  yylsp = yyls;
-#if defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL
-  /* Initialize the default location before parsing starts.  */
-  yylloc.first_line   = yylloc.last_line   = 1;
-  yylloc.first_column = yylloc.last_column = 0;
-#endif
-
+  yylsp[0] = yylloc;
   goto yysetstate;
 
+
 /*------------------------------------------------------------.
-| yynewstate -- Push a new state, which is found in yystate.  |
+| yynewstate -- push a new state, which is found in yystate.  |
 `------------------------------------------------------------*/
- yynewstate:
+yynewstate:
   /* In all cases, when you get here, the value and location stacks
      have just been pushed.  So pushing a state here evens the stacks.  */
   yyssp++;
 
- yysetstate:
-  *yyssp = yystate;
+
+/*--------------------------------------------------------------------.
+| yysetstate -- set current state (the top of the stack) to yystate.  |
+`--------------------------------------------------------------------*/
+yysetstate:
+  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
+  YY_ASSERT (0 <= yystate && yystate < YYNSTATES);
+  YY_IGNORE_USELESS_CAST_BEGIN
+  *yyssp = YY_CAST (yy_state_t, yystate);
+  YY_IGNORE_USELESS_CAST_END
+  YY_STACK_PRINT (yyss, yyssp);
 
   if (yyss + yystacksize - 1 <= yyssp)
+#if !defined yyoverflow && !defined YYSTACK_RELOCATE
+    YYNOMEM;
+#else
     {
       /* Get the current used size of the three stacks, in elements.  */
-      YYSIZE_T yysize = yyssp - yyss + 1;
+      YYPTRDIFF_T yysize = yyssp - yyss + 1;
 
-#ifdef yyoverflow
+# if defined yyoverflow
       {
-	/* Give user a chance to reallocate the stack.  Use copies of
-	   these so that the &'s don't force the real ones into
-	   memory.  */
-	YYSTYPE *yyvs1 = yyvs;
-	yytype_int16 *yyss1 = yyss;
-	YYLTYPE *yyls1 = yyls;
+        /* Give user a chance to reallocate the stack.  Use copies of
+           these so that the &'s don't force the real ones into
+           memory.  */
+        yy_state_t *yyss1 = yyss;
+        YYSTYPE *yyvs1 = yyvs;
+        YYLTYPE *yyls1 = yyls;
 
-	/* Each stack pointer address is followed by the size of the
-	   data in use in that stack, in bytes.  This used to be a
-	   conditional around just the two extra args, but that might
-	   be undefined if yyoverflow is a macro.  */
-	yyoverflow (YY_("memory exhausted"),
-		    &yyss1, yysize * sizeof (*yyssp),
-		    &yyvs1, yysize * sizeof (*yyvsp),
-		    &yyls1, yysize * sizeof (*yylsp),
-		    &yystacksize);
-	yyls = yyls1;
-	yyss = yyss1;
-	yyvs = yyvs1;
+        /* Each stack pointer address is followed by the size of the
+           data in use in that stack, in bytes.  This used to be a
+           conditional around just the two extra args, but that might
+           be undefined if yyoverflow is a macro.  */
+        yyoverflow (YY_("memory exhausted"),
+                    &yyss1, yysize * YYSIZEOF (*yyssp),
+                    &yyvs1, yysize * YYSIZEOF (*yyvsp),
+                    &yyls1, yysize * YYSIZEOF (*yylsp),
+                    &yystacksize);
+        yyss = yyss1;
+        yyvs = yyvs1;
+        yyls = yyls1;
       }
-#else /* no yyoverflow */
-# ifndef YYSTACK_RELOCATE
-      goto yyexhaustedlab;
-# else
+# else /* defined YYSTACK_RELOCATE */
       /* Extend the stack our own way.  */
       if (YYMAXDEPTH <= yystacksize)
-	goto yyexhaustedlab;
+        YYNOMEM;
       yystacksize *= 2;
       if (YYMAXDEPTH < yystacksize)
-	yystacksize = YYMAXDEPTH;
+        yystacksize = YYMAXDEPTH;
 
       {
-	yytype_int16 *yyss1 = yyss;
-	union yyalloc *yyptr =
-	  (union yyalloc *) YYSTACK_ALLOC (YYSTACK_BYTES (yystacksize));
-	if (! yyptr)
-	  goto yyexhaustedlab;
-	YYSTACK_RELOCATE (yyss);
-	YYSTACK_RELOCATE (yyvs);
-	YYSTACK_RELOCATE (yyls);
+        yy_state_t *yyss1 = yyss;
+        union yyalloc *yyptr =
+          YY_CAST (union yyalloc *,
+                   YYSTACK_ALLOC (YY_CAST (YYSIZE_T, YYSTACK_BYTES (yystacksize))));
+        if (! yyptr)
+          YYNOMEM;
+        YYSTACK_RELOCATE (yyss_alloc, yyss);
+        YYSTACK_RELOCATE (yyvs_alloc, yyvs);
+        YYSTACK_RELOCATE (yyls_alloc, yyls);
 #  undef YYSTACK_RELOCATE
-	if (yyss1 != yyssa)
-	  YYSTACK_FREE (yyss1);
+        if (yyss1 != yyssa)
+          YYSTACK_FREE (yyss1);
       }
 # endif
-#endif /* no yyoverflow */
 
       yyssp = yyss + yysize - 1;
       yyvsp = yyvs + yysize - 1;
       yylsp = yyls + yysize - 1;
 
-      YYDPRINTF ((stderr, "Stack size increased to %lu\n",
-		  (unsigned long int) yystacksize));
+      YY_IGNORE_USELESS_CAST_BEGIN
+      YYDPRINTF ((stderr, "Stack size increased to %ld\n",
+                  YY_CAST (long, yystacksize)));
+      YY_IGNORE_USELESS_CAST_END
 
       if (yyss + yystacksize - 1 <= yyssp)
-	YYABORT;
+        YYABORT;
     }
+#endif /* !defined yyoverflow && !defined YYSTACK_RELOCATE */
 
-  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
+
+  if (yystate == YYFINAL)
+    YYACCEPT;
 
   goto yybackup;
+
 
 /*-----------.
 | yybackup.  |
 `-----------*/
 yybackup:
-
   /* Do appropriate processing given the current state.  Read a
-     look-ahead token if we need one and don't already have one.  */
+     lookahead token if we need one and don't already have one.  */
 
-  /* First try to decide what to do without reference to look-ahead token.  */
+  /* First try to decide what to do without reference to lookahead token.  */
   yyn = yypact[yystate];
-  if (yyn == YYPACT_NINF)
+  if (yypact_value_is_default (yyn))
     goto yydefault;
 
-  /* Not known => get a look-ahead token if don't already have one.  */
+  /* Not known => get a lookahead token if don't already have one.  */
 
-  /* YYCHAR is either YYEMPTY or YYEOF or a valid look-ahead symbol.  */
+  /* YYCHAR is either empty, or end-of-input, or a valid lookahead.  */
   if (yychar == YYEMPTY)
     {
-      YYDPRINTF ((stderr, "Reading a token: "));
-      yychar = YYLEX;
+      YYDPRINTF ((stderr, "Reading a token\n"));
+      yychar = yylex ();
     }
 
   if (yychar <= YYEOF)
     {
-      yychar = yytoken = YYEOF;
+      yychar = YYEOF;
+      yytoken = YYSYMBOL_YYEOF;
       YYDPRINTF ((stderr, "Now at end of input.\n"));
+    }
+  else if (yychar == YYerror)
+    {
+      /* The scanner already issued an error message, process directly
+         to error recovery.  But do not keep the error token as
+         lookahead, it is too special and may lead us to an endless
+         loop in error recovery. */
+      yychar = YYUNDEF;
+      yytoken = YYSYMBOL_YYerror;
+      yyerror_range[1] = yylloc;
+      goto yyerrlab1;
     }
   else
     {
@@ -1843,30 +1647,27 @@ yybackup:
   yyn = yytable[yyn];
   if (yyn <= 0)
     {
-      if (yyn == 0 || yyn == YYTABLE_NINF)
-	goto yyerrlab;
+      if (yytable_value_is_error (yyn))
+        goto yyerrlab;
       yyn = -yyn;
       goto yyreduce;
     }
-
-  if (yyn == YYFINAL)
-    YYACCEPT;
 
   /* Count tokens shifted since error; after three, turn off error
      status.  */
   if (yyerrstatus)
     yyerrstatus--;
 
-  /* Shift the look-ahead token.  */
+  /* Shift the lookahead token.  */
   YY_SYMBOL_PRINT ("Shifting", yytoken, &yylval, &yylloc);
-
-  /* Discard the shifted token unless it is eof.  */
-  if (yychar != YYEOF)
-    yychar = YYEMPTY;
-
   yystate = yyn;
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   *++yyvsp = yylval;
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
   *++yylsp = yylloc;
+
+  /* Discard the shifted token.  */
+  yychar = YYEMPTY;
   goto yynewstate;
 
 
@@ -1881,14 +1682,14 @@ yydefault:
 
 
 /*-----------------------------.
-| yyreduce -- Do a reduction.  |
+| yyreduce -- do a reduction.  |
 `-----------------------------*/
 yyreduce:
   /* yyn is the number of a rule to reduce with.  */
   yylen = yyr2[yyn];
 
   /* If YYLEN is nonzero, implement the default value of the action:
-     `$$ = $1'.
+     '$$ = $1'.
 
      Otherwise, the following line sets YYVAL to garbage.
      This behavior is undocumented and Bison
@@ -1897,478 +1698,515 @@ yyreduce:
      GCC warning that YYVAL may be used uninitialized.  */
   yyval = yyvsp[1-yylen];
 
-  /* Default location.  */
+  /* Default location. */
   YYLLOC_DEFAULT (yyloc, (yylsp - yylen), yylen);
+  yyerror_range[1] = yyloc;
   YY_REDUCE_PRINT (yyn);
   switch (yyn)
     {
-        case 2:
-#line 450 "hoa.y"
-    {
+  case 2: /* automaton: header BEGINBODY body ENDBODY  */
+#line 466 "hoa.y"
+         {
             if (!seenHeader[HOAHDR]) /* redundant because of the grammar */
                 yyerror("No HOA: header item");
             if (!seenHeader[ACCEPTANCE])
                 yyerror("No Acceptance: header item");
-         ;}
+         }
+#line 1716 "hoaparser.c"
     break;
 
-  case 4:
-#line 460 "hoa.y"
-    {
-                  loadedData->version = (yyvsp[(2) - (2)].string);
+  case 4: /* format_version: HOAHDR IDENTIFIER  */
+#line 476 "hoa.y"
+              {
+                  loadedData->version = (yyvsp[0].string);
                   if (seenHeader[HOAHDR])
                       hdrItemError("HOA:");
                   else
                       seenHeader[HOAHDR] = true;
-              ;}
+              }
+#line 1728 "hoaparser.c"
     break;
 
-  case 5:
-#line 468 "hoa.y"
-    { /* no new item, nothing to check */ ;}
+  case 5: /* header_list: %empty  */
+#line 484 "hoa.y"
+                         { /* no new item, nothing to check */ }
+#line 1734 "hoaparser.c"
     break;
 
-  case 6:
-#line 470 "hoa.y"
-    {
-               if ((yyvsp[(2) - (2)].number) <= 8) {
-                   if (seenHeader[(yyvsp[(2) - (2)].number)])
-                       hdrItemError(headerStrs[(yyvsp[(2) - (2)].number)]);
+  case 6: /* header_list: header_list header_item  */
+#line 486 "hoa.y"
+           {
+               if ((yyvsp[0].number) <= 8) {
+                   if (seenHeader[(yyvsp[0].number)])
+                       hdrItemError(headerStrs[(yyvsp[0].number)]);
                    else
-                       seenHeader[(yyvsp[(2) - (2)].number)] = true;
+                       seenHeader[(yyvsp[0].number)] = true;
                }
-           ;}
+           }
+#line 1747 "hoaparser.c"
     break;
 
-  case 7:
-#line 479 "hoa.y"
-    {
-                                                 loadedData->noStates = (yyvsp[(2) - (2)].number);
+  case 7: /* header_item: STATES INT  */
+#line 495 "hoa.y"
+                                               {
+                                                 loadedData->noStates = (yyvsp[0].number);
                                                  (yyval.number) = STATES;
-                                               ;}
+                                               }
+#line 1756 "hoaparser.c"
     break;
 
-  case 8:
-#line 483 "hoa.y"
-    {
+  case 8: /* header_item: START state_conj  */
+#line 499 "hoa.y"
+                                               {
                                                  tempStart =
                                                     concatIntLists(
                                                         tempStart,
-                                                        (yyvsp[(2) - (2)].numlist)
+                                                        (yyvsp[0].numlist)
                                                     );
                                                  (yyval.number) = START;
-                                               ;}
+                                               }
+#line 1769 "hoaparser.c"
     break;
 
-  case 9:
-#line 491 "hoa.y"
-    {
-                                                 loadedData->noAPs = (yyvsp[(2) - (3)].number);
-                                                 tempAps = (yyvsp[(3) - (3)].strlist);
+  case 9: /* header_item: AP INT string_list  */
+#line 507 "hoa.y"
+                                               {
+                                                 loadedData->noAPs = (yyvsp[-1].number);
+                                                 tempAps = (yyvsp[0].strlist);
                                                  (yyval.number) = AP;
-                                               ;}
+                                               }
+#line 1779 "hoaparser.c"
     break;
 
-  case 10:
-#line 496 "hoa.y"
-    {
-                                                 tempCntAPs = (yyvsp[(2) - (2)].numlist);
+  case 10: /* header_item: CNTAP int_list  */
+#line 512 "hoa.y"
+                                               {
+                                                 tempCntAPs = (yyvsp[0].numlist);
                                                  (yyval.number) = CNTAP;
-                                               ;}
+                                               }
+#line 1788 "hoaparser.c"
     break;
 
-  case 11:
-#line 500 "hoa.y"
-    {
+  case 11: /* header_item: ALIAS ANAME label_expr  */
+#line 516 "hoa.y"
+                                               {
                                                  tempAliases =
                                                     prependAliasNode(
                                                         tempAliases,
-                                                        (yyvsp[(2) - (3)].string), (yyvsp[(3) - (3)].tree)
+                                                        (yyvsp[-1].string), (yyvsp[0].tree)
                                                     );
                                                  (yyval.number) = ALIAS;
-                                               ;}
+                                               }
+#line 1801 "hoaparser.c"
     break;
 
-  case 12:
-#line 508 "hoa.y"
-    { 
-                                                 loadedData->noAccSets = (yyvsp[(2) - (3)].number);
-                                                 loadedData->acc = (yyvsp[(3) - (3)].tree);
+  case 12: /* header_item: ACCEPTANCE INT acceptance_cond  */
+#line 524 "hoa.y"
+                                               { 
+                                                 loadedData->noAccSets = (yyvsp[-1].number);
+                                                 loadedData->acc = (yyvsp[0].tree);
                                                  (yyval.number) = ACCEPTANCE;
-                                               ;}
+                                               }
+#line 1811 "hoaparser.c"
     break;
 
-  case 13:
-#line 513 "hoa.y"
-    { 
-                                                 loadedData->accNameID = (yyvsp[(2) - (3)].string);
+  case 13: /* header_item: ACCNAME IDENTIFIER boolintid_list  */
+#line 529 "hoa.y"
+                                               { 
+                                                 loadedData->accNameID = (yyvsp[-1].string);
                                                  tempAccNameParameters
                                                     = concatStrLists(
                                                         tempAccNameParameters,
-                                                        (yyvsp[(3) - (3)].strlist)
+                                                        (yyvsp[0].strlist)
                                                     );
                                                  (yyval.number) = ACCNAME;
-                                               ;}
+                                               }
+#line 1825 "hoaparser.c"
     break;
 
-  case 14:
-#line 522 "hoa.y"
-    { (yyval.number) = TOOL; ;}
+  case 14: /* header_item: TOOL STRING maybe_string  */
+#line 538 "hoa.y"
+                                               { (yyval.number) = TOOL; }
+#line 1831 "hoaparser.c"
     break;
 
-  case 15:
-#line 523 "hoa.y"
-    {
-                                                 loadedData->name = (yyvsp[(2) - (2)].string);
+  case 15: /* header_item: NAME STRING  */
+#line 539 "hoa.y"
+                                               {
+                                                 loadedData->name = (yyvsp[0].string);
                                                  (yyval.number) = NAME;
-                                               ;}
+                                               }
+#line 1840 "hoaparser.c"
     break;
 
-  case 16:
-#line 527 "hoa.y"
-    { 
+  case 16: /* header_item: PROPERTIES id_list  */
+#line 543 "hoa.y"
+                                               { 
                                                  tempProperties =
                                                      concatStrLists(
                                                          tempProperties,
-                                                         (yyvsp[(2) - (2)].strlist)
+                                                         (yyvsp[0].strlist)
                                                      );
                                                  (yyval.number) = PROPERTIES;
-                                               ;}
+                                               }
+#line 1853 "hoaparser.c"
     break;
 
-  case 17:
-#line 535 "hoa.y"
-    { free((yyvsp[(1) - (2)].string)); (yyval.number) = HEADERNAME; ;}
-    break;
-
-  case 18:
-#line 538 "hoa.y"
-    { (yyval.numlist) = newIntNode((yyvsp[(1) - (1)].number)); ;}
-    break;
-
-  case 19:
-#line 539 "hoa.y"
-    { (yyval.numlist) = prependIntNode((yyvsp[(3) - (3)].numlist), (yyvsp[(1) - (3)].number)); ;}
-    break;
-
-  case 20:
-#line 542 "hoa.y"
-    { (yyval.tree) = (yyvsp[(1) - (1)].tree); ;}
-    break;
-
-  case 21:
-#line 543 "hoa.y"
-    { (yyval.tree) = orBTree((yyvsp[(1) - (3)].tree), (yyvsp[(3) - (3)].tree)); ;}
-    break;
-
-  case 22:
-#line 546 "hoa.y"
-    { (yyval.tree) = (yyvsp[(1) - (1)].tree); ;}
-    break;
-
-  case 23:
-#line 547 "hoa.y"
-    { (yyval.tree) = andBTree((yyvsp[(1) - (3)].tree), (yyvsp[(3) - (3)].tree)); ;}
-    break;
-
-  case 24:
-#line 550 "hoa.y"
-    { (yyval.tree) = boolBTree((yyvsp[(1) - (1)].boolean)); ;}
-    break;
-
-  case 25:
+  case 17: /* header_item: HEADERNAME boolintstrid_list  */
 #line 551 "hoa.y"
-    { (yyval.tree) = apBTree((yyvsp[(1) - (1)].number)); ;}
+                                               { free((yyvsp[-1].string)); (yyval.number) = HEADERNAME; }
+#line 1859 "hoaparser.c"
     break;
 
-  case 26:
-#line 552 "hoa.y"
-    { (yyval.tree) = aliasBTree((yyvsp[(1) - (1)].string)); ;}
-    break;
-
-  case 27:
-#line 553 "hoa.y"
-    { (yyval.tree) = notBTree((yyvsp[(2) - (2)].tree)); ;}
-    break;
-
-  case 28:
+  case 18: /* state_conj: INT  */
 #line 554 "hoa.y"
-    { (yyval.tree) = (yyvsp[(2) - (3)].tree); ;}
+                                { (yyval.numlist) = newIntNode((yyvsp[0].number)); }
+#line 1865 "hoaparser.c"
     break;
 
-  case 29:
-#line 557 "hoa.y"
-    { (yyval.tree) = (yyvsp[(1) - (1)].tree); ;}
+  case 19: /* state_conj: INT "&" state_conj  */
+#line 555 "hoa.y"
+                                { (yyval.numlist) = prependIntNode((yyvsp[0].numlist), (yyvsp[-2].number)); }
+#line 1871 "hoaparser.c"
     break;
 
-  case 30:
+  case 20: /* label_expr: lab_exp_conj  */
 #line 558 "hoa.y"
-    { (yyval.tree) = orBTree((yyvsp[(1) - (3)].tree), (yyvsp[(3) - (3)].tree)); ;}
+                                        { (yyval.tree) = (yyvsp[0].tree); }
+#line 1877 "hoaparser.c"
     break;
 
-  case 31:
-#line 561 "hoa.y"
-    { (yyval.tree) = (yyvsp[(1) - (1)].tree); ;}
+  case 21: /* label_expr: label_expr "|" lab_exp_conj  */
+#line 559 "hoa.y"
+                                        { (yyval.tree) = orBTree((yyvsp[-2].tree), (yyvsp[0].tree)); }
+#line 1883 "hoaparser.c"
     break;
 
-  case 32:
+  case 22: /* lab_exp_conj: lab_exp_atom  */
 #line 562 "hoa.y"
-    { (yyval.tree) = andBTree((yyvsp[(1) - (3)].tree), (yyvsp[(3) - (3)].tree)); ;}
+                                            { (yyval.tree) = (yyvsp[0].tree); }
+#line 1889 "hoaparser.c"
     break;
 
-  case 33:
-#line 565 "hoa.y"
-    { (yyval.tree) = accidBTree((yyvsp[(1) - (4)].nodetype), (yyvsp[(3) - (4)].number), false); ;}
+  case 23: /* lab_exp_conj: lab_exp_conj "&" lab_exp_atom  */
+#line 563 "hoa.y"
+                                            { (yyval.tree) = andBTree((yyvsp[-2].tree), (yyvsp[0].tree)); }
+#line 1895 "hoaparser.c"
     break;
 
-  case 34:
+  case 24: /* lab_exp_atom: BOOL  */
 #line 566 "hoa.y"
-    { (yyval.tree) = accidBTree((yyvsp[(1) - (5)].nodetype), (yyvsp[(4) - (5)].number), true); ;}
+                                 { (yyval.tree) = boolBTree((yyvsp[0].boolean)); }
+#line 1901 "hoaparser.c"
     break;
 
-  case 35:
+  case 25: /* lab_exp_atom: INT  */
 #line 567 "hoa.y"
-    { (yyval.tree) = (yyvsp[(2) - (3)].tree); ;}
+                                 { (yyval.tree) = apBTree((yyvsp[0].number)); }
+#line 1907 "hoaparser.c"
     break;
 
-  case 36:
+  case 26: /* lab_exp_atom: ANAME  */
 #line 568 "hoa.y"
-    { (yyval.tree) = boolBTree((yyvsp[(1) - (1)].boolean)); ;}
+                                 { (yyval.tree) = aliasBTree((yyvsp[0].string)); }
+#line 1913 "hoaparser.c"
     break;
 
-  case 37:
-#line 571 "hoa.y"
-    { (yyval.nodetype) = NT_FIN; ;}
+  case 27: /* lab_exp_atom: "!" lab_exp_atom  */
+#line 569 "hoa.y"
+                                 { (yyval.tree) = notBTree((yyvsp[0].tree)); }
+#line 1919 "hoaparser.c"
     break;
 
-  case 38:
-#line 572 "hoa.y"
-    { (yyval.nodetype) = NT_INF; ;}
+  case 28: /* lab_exp_atom: "(" label_expr ")"  */
+#line 570 "hoa.y"
+                                 { (yyval.tree) = (yyvsp[-1].tree); }
+#line 1925 "hoaparser.c"
     break;
 
-  case 39:
-#line 575 "hoa.y"
-    { (yyval.strlist) = NULL; ;}
+  case 29: /* acceptance_cond: acc_cond_conj  */
+#line 573 "hoa.y"
+                                                   { (yyval.tree) = (yyvsp[0].tree); }
+#line 1931 "hoaparser.c"
     break;
 
-  case 40:
-#line 576 "hoa.y"
-    { 
-                                            (yyval.strlist) = (yyvsp[(1) - (2)].boolean) ? prependStrNode((yyvsp[(2) - (2)].strlist),
-                                                                     strdup("True"))
-                                                : prependStrNode((yyvsp[(2) - (2)].strlist),
-                                                                 strdup("False"));
-                                          ;}
+  case 30: /* acceptance_cond: acceptance_cond "|" acc_cond_conj  */
+#line 574 "hoa.y"
+                                                   { (yyval.tree) = orBTree((yyvsp[-2].tree), (yyvsp[0].tree)); }
+#line 1937 "hoaparser.c"
     break;
 
-  case 41:
+  case 31: /* acc_cond_conj: acc_cond_atom  */
+#line 577 "hoa.y"
+                                               { (yyval.tree) = (yyvsp[0].tree); }
+#line 1943 "hoaparser.c"
+    break;
+
+  case 32: /* acc_cond_conj: acc_cond_conj "&" acc_cond_atom  */
+#line 578 "hoa.y"
+                                               { (yyval.tree) = andBTree((yyvsp[-2].tree), (yyvsp[0].tree)); }
+#line 1949 "hoaparser.c"
+    break;
+
+  case 33: /* acc_cond_atom: accid "(" INT ")"  */
+#line 581 "hoa.y"
+                                       { (yyval.tree) = accidBTree((yyvsp[-3].nodetype), (yyvsp[-1].number), false); }
+#line 1955 "hoaparser.c"
+    break;
+
+  case 34: /* acc_cond_atom: accid "(" "!" INT ")"  */
 #line 582 "hoa.y"
-    {
-                                            char buffer[66];
-                                            sprintf(buffer, "%d", (yyvsp[(1) - (2)].number));
-                                            (yyval.strlist) = prependStrNode((yyvsp[(2) - (2)].strlist),
-                                                                strdup(buffer));
-                                          ;}
+                                       { (yyval.tree) = accidBTree((yyvsp[-4].nodetype), (yyvsp[-1].number), true); }
+#line 1961 "hoaparser.c"
     break;
 
-  case 42:
+  case 35: /* acc_cond_atom: "(" acceptance_cond ")"  */
+#line 583 "hoa.y"
+                                       { (yyval.tree) = (yyvsp[-1].tree); }
+#line 1967 "hoaparser.c"
+    break;
+
+  case 36: /* acc_cond_atom: BOOL  */
+#line 584 "hoa.y"
+                                       { (yyval.tree) = boolBTree((yyvsp[0].boolean)); }
+#line 1973 "hoaparser.c"
+    break;
+
+  case 37: /* accid: FIN  */
+#line 587 "hoa.y"
+           { (yyval.nodetype) = NT_FIN; }
+#line 1979 "hoaparser.c"
+    break;
+
+  case 38: /* accid: INF  */
 #line 588 "hoa.y"
-    { (yyval.strlist) = prependStrNode((yyvsp[(2) - (2)].strlist), (yyvsp[(1) - (2)].string)); ;}
+           { (yyval.nodetype) = NT_INF; }
+#line 1985 "hoaparser.c"
     break;
 
-  case 47:
-#line 595 "hoa.y"
-    { free((yyvsp[(2) - (2)].string)); ;}
+  case 39: /* boolintid_list: %empty  */
+#line 591 "hoa.y"
+                                          { (yyval.strlist) = NULL; }
+#line 1991 "hoaparser.c"
     break;
 
-  case 48:
-#line 597 "hoa.y"
-    { (yyval.strlist) = NULL; ;}
+  case 40: /* boolintid_list: BOOL boolintid_list  */
+#line 592 "hoa.y"
+                                          { 
+                                            (yyval.strlist) = (yyvsp[-1].boolean) ? prependStrNode((yyvsp[0].strlist),
+                                                                     strdup("True"))
+                                                : prependStrNode((yyvsp[0].strlist),
+                                                                 strdup("False"));
+                                          }
+#line 2002 "hoaparser.c"
     break;
 
-  case 49:
+  case 41: /* boolintid_list: INT boolintid_list  */
 #line 598 "hoa.y"
-    { (yyval.strlist) = prependStrNode((yyvsp[(2) - (2)].strlist), (yyvsp[(1) - (2)].string)); ;}
+                                          {
+                                            char buffer[66];
+                                            sprintf(buffer, "%d", (yyvsp[-1].number));
+                                            (yyval.strlist) = prependStrNode((yyvsp[0].strlist),
+                                                                strdup(buffer));
+                                          }
+#line 2013 "hoaparser.c"
     break;
 
-  case 50:
-#line 601 "hoa.y"
-    { (yyval.strlist) = NULL; ;}
+  case 42: /* boolintid_list: IDENTIFIER boolintid_list  */
+#line 604 "hoa.y"
+                                          { (yyval.strlist) = prependStrNode((yyvsp[0].strlist), (yyvsp[-1].string)); }
+#line 2019 "hoaparser.c"
     break;
 
-  case 51:
-#line 602 "hoa.y"
-    { (yyval.strlist) = prependStrNode((yyvsp[(2) - (2)].strlist), (yyvsp[(1) - (2)].string)); ;}
-    break;
-
-  case 52:
-#line 606 "hoa.y"
-    { tempStates = (yyvsp[(1) - (1)].statelist); ;}
-    break;
-
-  case 53:
-#line 609 "hoa.y"
-    { (yyval.statelist) = NULL; ;}
-    break;
-
-  case 54:
+  case 47: /* boolintstrid_list: boolintstrid_list IDENTIFIER  */
 #line 611 "hoa.y"
-    {
-                (yyval.statelist) = prependStateNode((yyvsp[(3) - (3)].statelist), (yyvsp[(1) - (3)].statelist), (yyvsp[(2) - (3)].trlist));
-              ;}
+                                                { free((yyvsp[0].string)); }
+#line 2025 "hoaparser.c"
     break;
 
-  case 55:
+  case 48: /* string_list: %empty  */
+#line 613 "hoa.y"
+                                { (yyval.strlist) = NULL; }
+#line 2031 "hoaparser.c"
+    break;
+
+  case 49: /* string_list: STRING string_list  */
+#line 614 "hoa.y"
+                                { (yyval.strlist) = prependStrNode((yyvsp[0].strlist), (yyvsp[-1].string)); }
+#line 2037 "hoaparser.c"
+    break;
+
+  case 50: /* id_list: %empty  */
 #line 617 "hoa.y"
-    { (yyval.statelist) = newStateNode((yyvsp[(3) - (5)].number), (yyvsp[(4) - (5)].string), (yyvsp[(2) - (5)].tree), (yyvsp[(5) - (5)].numlist)); ;}
+                            { (yyval.strlist) = NULL; }
+#line 2043 "hoaparser.c"
     break;
 
-  case 56:
-#line 620 "hoa.y"
-    { (yyval.tree) = NULL; ;}
+  case 51: /* id_list: IDENTIFIER id_list  */
+#line 618 "hoa.y"
+                            { (yyval.strlist) = prependStrNode((yyvsp[0].strlist), (yyvsp[-1].string)); }
+#line 2049 "hoaparser.c"
     break;
 
-  case 57:
-#line 621 "hoa.y"
-    { (yyval.tree) = (yyvsp[(2) - (3)].tree); ;}
+  case 52: /* body: statespec_list  */
+#line 622 "hoa.y"
+    { tempStates = (yyvsp[0].statelist); }
+#line 2055 "hoaparser.c"
     break;
 
-  case 58:
-#line 624 "hoa.y"
-    { (yyval.string) = NULL; ;}
-    break;
-
-  case 59:
+  case 53: /* statespec_list: %empty  */
 #line 625 "hoa.y"
-    { (yyval.string) = (yyvsp[(1) - (1)].string); ;}
+                            { (yyval.statelist) = NULL; }
+#line 2061 "hoaparser.c"
     break;
 
-  case 60:
-#line 628 "hoa.y"
-    { (yyval.numlist) = NULL; ;}
+  case 54: /* statespec_list: statespec_list state_name trans_list  */
+#line 627 "hoa.y"
+              {
+                (yyval.statelist) = appendStateNode((yyvsp[-2].statelist), (yyvsp[-1].statelist), (yyvsp[0].trlist));
+              }
+#line 2069 "hoaparser.c"
     break;
 
-  case 61:
-#line 629 "hoa.y"
-    { (yyval.numlist) = (yyvsp[(2) - (3)].numlist); ;}
-    break;
-
-  case 62:
-#line 632 "hoa.y"
-    { (yyval.numlist) = NULL; ;}
-    break;
-
-  case 63:
+  case 55: /* state_name: STATEHDR maybe_label INT maybe_string maybe_accsig  */
 #line 633 "hoa.y"
-    { (yyval.numlist) = prependIntNode((yyvsp[(2) - (2)].numlist), (yyvsp[(1) - (2)].number)); ;}
+          { (yyval.statelist) = newStateNode((yyvsp[-2].number), (yyvsp[-1].string), (yyvsp[-3].tree), (yyvsp[0].numlist)); }
+#line 2075 "hoaparser.c"
     break;
 
-  case 64:
+  case 56: /* maybe_label: %empty  */
 #line 636 "hoa.y"
-    { (yyval.trlist) = NULL; ;}
+                                { (yyval.tree) = NULL; }
+#line 2081 "hoaparser.c"
     break;
 
-  case 65:
-#line 638 "hoa.y"
-    { (yyval.trlist) = prependTransNode((yyvsp[(4) - (4)].trlist), (yyvsp[(1) - (4)].tree), (yyvsp[(2) - (4)].numlist), (yyvsp[(3) - (4)].numlist)); ;}
+  case 57: /* maybe_label: "[" label_expr "]"  */
+#line 637 "hoa.y"
+                                { (yyval.tree) = (yyvsp[-1].tree); }
+#line 2087 "hoaparser.c"
+    break;
+
+  case 58: /* maybe_string: %empty  */
+#line 640 "hoa.y"
+                          { (yyval.string) = NULL; }
+#line 2093 "hoaparser.c"
+    break;
+
+  case 59: /* maybe_string: STRING  */
+#line 641 "hoa.y"
+                          { (yyval.string) = (yyvsp[0].string); }
+#line 2099 "hoaparser.c"
+    break;
+
+  case 60: /* maybe_accsig: %empty  */
+#line 644 "hoa.y"
+                               { (yyval.numlist) = NULL; }
+#line 2105 "hoaparser.c"
+    break;
+
+  case 61: /* maybe_accsig: "{" int_list "}"  */
+#line 645 "hoa.y"
+                               { (yyval.numlist) = (yyvsp[-1].numlist); }
+#line 2111 "hoaparser.c"
+    break;
+
+  case 62: /* int_list: %empty  */
+#line 648 "hoa.y"
+                       { (yyval.numlist) = NULL; }
+#line 2117 "hoaparser.c"
+    break;
+
+  case 63: /* int_list: INT int_list  */
+#line 649 "hoa.y"
+                       { (yyval.numlist) = prependIntNode((yyvsp[0].numlist), (yyvsp[-1].number)); }
+#line 2123 "hoaparser.c"
+    break;
+
+  case 64: /* trans_list: %empty  */
+#line 652 "hoa.y"
+                        { (yyval.trlist) = NULL; }
+#line 2129 "hoaparser.c"
+    break;
+
+  case 65: /* trans_list: maybe_label state_conj maybe_accsig trans_list  */
+#line 654 "hoa.y"
+          { (yyval.trlist) = prependTransNode((yyvsp[0].trlist), (yyvsp[-3].tree), (yyvsp[-2].numlist), (yyvsp[-1].numlist)); }
+#line 2135 "hoaparser.c"
     break;
 
 
-/* Line 1267 of yacc.c.  */
-#line 2279 "hoaparser.c"
+#line 2139 "hoaparser.c"
+
       default: break;
     }
-  YY_SYMBOL_PRINT ("-> $$ =", yyr1[yyn], &yyval, &yyloc);
+  /* User semantic actions sometimes alter yychar, and that requires
+     that yytoken be updated with the new translation.  We take the
+     approach of translating immediately before every use of yytoken.
+     One alternative is translating here after every semantic action,
+     but that translation would be missed if the semantic action invokes
+     YYABORT, YYACCEPT, or YYERROR immediately after altering yychar or
+     if it invokes YYBACKUP.  In the case of YYABORT or YYACCEPT, an
+     incorrect destructor might then be invoked immediately.  In the
+     case of YYERROR or YYBACKUP, subsequent parser actions might lead
+     to an incorrect destructor call or verbose syntax error message
+     before the lookahead is translated.  */
+  YY_SYMBOL_PRINT ("-> $$ =", YY_CAST (yysymbol_kind_t, yyr1[yyn]), &yyval, &yyloc);
 
   YYPOPSTACK (yylen);
   yylen = 0;
-  YY_STACK_PRINT (yyss, yyssp);
 
   *++yyvsp = yyval;
   *++yylsp = yyloc;
 
-  /* Now `shift' the result of the reduction.  Determine what state
+  /* Now 'shift' the result of the reduction.  Determine what state
      that goes to, based on the state we popped back to and the rule
      number reduced by.  */
-
-  yyn = yyr1[yyn];
-
-  yystate = yypgoto[yyn - YYNTOKENS] + *yyssp;
-  if (0 <= yystate && yystate <= YYLAST && yycheck[yystate] == *yyssp)
-    yystate = yytable[yystate];
-  else
-    yystate = yydefgoto[yyn - YYNTOKENS];
+  {
+    const int yylhs = yyr1[yyn] - YYNTOKENS;
+    const int yyi = yypgoto[yylhs] + *yyssp;
+    yystate = (0 <= yyi && yyi <= YYLAST && yycheck[yyi] == *yyssp
+               ? yytable[yyi]
+               : yydefgoto[yylhs]);
+  }
 
   goto yynewstate;
 
 
-/*------------------------------------.
-| yyerrlab -- here on detecting error |
-`------------------------------------*/
+/*--------------------------------------.
+| yyerrlab -- here on detecting error.  |
+`--------------------------------------*/
 yyerrlab:
+  /* Make sure we have latest lookahead translation.  See comments at
+     user semantic actions for why this is necessary.  */
+  yytoken = yychar == YYEMPTY ? YYSYMBOL_YYEMPTY : YYTRANSLATE (yychar);
   /* If not already recovering from an error, report this error.  */
   if (!yyerrstatus)
     {
       ++yynerrs;
-#if ! YYERROR_VERBOSE
       yyerror (YY_("syntax error"));
-#else
-      {
-	YYSIZE_T yysize = yysyntax_error (0, yystate, yychar);
-	if (yymsg_alloc < yysize && yymsg_alloc < YYSTACK_ALLOC_MAXIMUM)
-	  {
-	    YYSIZE_T yyalloc = 2 * yysize;
-	    if (! (yysize <= yyalloc && yyalloc <= YYSTACK_ALLOC_MAXIMUM))
-	      yyalloc = YYSTACK_ALLOC_MAXIMUM;
-	    if (yymsg != yymsgbuf)
-	      YYSTACK_FREE (yymsg);
-	    yymsg = (char *) YYSTACK_ALLOC (yyalloc);
-	    if (yymsg)
-	      yymsg_alloc = yyalloc;
-	    else
-	      {
-		yymsg = yymsgbuf;
-		yymsg_alloc = sizeof yymsgbuf;
-	      }
-	  }
-
-	if (0 < yysize && yysize <= yymsg_alloc)
-	  {
-	    (void) yysyntax_error (yymsg, yystate, yychar);
-	    yyerror (yymsg);
-	  }
-	else
-	  {
-	    yyerror (YY_("syntax error"));
-	    if (yysize != 0)
-	      goto yyexhaustedlab;
-	  }
-      }
-#endif
     }
 
-  yyerror_range[0] = yylloc;
-
+  yyerror_range[1] = yylloc;
   if (yyerrstatus == 3)
     {
-      /* If just tried and failed to reuse look-ahead token after an
-	 error, discard it.  */
+      /* If just tried and failed to reuse lookahead token after an
+         error, discard it.  */
 
       if (yychar <= YYEOF)
-	{
-	  /* Return failure if at end of input.  */
-	  if (yychar == YYEOF)
-	    YYABORT;
-	}
+        {
+          /* Return failure if at end of input.  */
+          if (yychar == YYEOF)
+            YYABORT;
+        }
       else
-	{
-	  yydestruct ("Error: discarding",
-		      yytoken, &yylval, &yylloc);
-	  yychar = YYEMPTY;
-	}
+        {
+          yydestruct ("Error: discarding",
+                      yytoken, &yylval, &yylloc);
+          yychar = YYEMPTY;
+        }
     }
 
-  /* Else will try to reuse look-ahead token after shifting the error
+  /* Else will try to reuse lookahead token after shifting the error
      token.  */
   goto yyerrlab1;
 
@@ -2377,15 +2215,13 @@ yyerrlab:
 | yyerrorlab -- error raised explicitly by YYERROR.  |
 `---------------------------------------------------*/
 yyerrorlab:
+  /* Pacify compilers when the user code never invokes YYERROR and the
+     label yyerrorlab therefore never appears in user code.  */
+  if (0)
+    YYERROR;
+  ++yynerrs;
 
-  /* Pacify compilers like GCC when the user code never invokes
-     YYERROR and the label yyerrorlab therefore never appears in user
-     code.  */
-  if (/*CONSTCOND*/ 0)
-     goto yyerrorlab;
-
-  yyerror_range[0] = yylsp[1-yylen];
-  /* Do not reclaim the symbols of the rule which action triggered
+  /* Do not reclaim the symbols of the rule whose action triggered
      this YYERROR.  */
   YYPOPSTACK (yylen);
   yylen = 0;
@@ -2398,47 +2234,45 @@ yyerrorlab:
 | yyerrlab1 -- common code for both syntax error and YYERROR.  |
 `-------------------------------------------------------------*/
 yyerrlab1:
-  yyerrstatus = 3;	/* Each real token shifted decrements this.  */
+  yyerrstatus = 3;      /* Each real token shifted decrements this.  */
 
+  /* Pop stack until we find a state that shifts the error token.  */
   for (;;)
     {
       yyn = yypact[yystate];
-      if (yyn != YYPACT_NINF)
-	{
-	  yyn += YYTERROR;
-	  if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
-	    {
-	      yyn = yytable[yyn];
-	      if (0 < yyn)
-		break;
-	    }
-	}
+      if (!yypact_value_is_default (yyn))
+        {
+          yyn += YYSYMBOL_YYerror;
+          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYSYMBOL_YYerror)
+            {
+              yyn = yytable[yyn];
+              if (0 < yyn)
+                break;
+            }
+        }
 
       /* Pop the current state because it cannot handle the error token.  */
       if (yyssp == yyss)
-	YYABORT;
+        YYABORT;
 
-      yyerror_range[0] = *yylsp;
+      yyerror_range[1] = *yylsp;
       yydestruct ("Error: popping",
-		  yystos[yystate], yyvsp, yylsp);
+                  YY_ACCESSING_SYMBOL (yystate), yyvsp, yylsp);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
     }
 
-  if (yyn == YYFINAL)
-    YYACCEPT;
-
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   *++yyvsp = yylval;
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 
-  yyerror_range[1] = yylloc;
-  /* Using YYLLOC is tempting, but would change the location of
-     the look-ahead.  YYLOC is available though.  */
-  YYLLOC_DEFAULT (yyloc, (yyerror_range - 1), 2);
-  *++yylsp = yyloc;
+  yyerror_range[2] = yylloc;
+  ++yylsp;
+  YYLLOC_DEFAULT (*yylsp, yyerror_range, 2);
 
   /* Shift the error token.  */
-  YY_SYMBOL_PRINT ("Shifting", yystos[yyn], yyvsp, yylsp);
+  YY_SYMBOL_PRINT ("Shifting", YY_ACCESSING_SYMBOL (yyn), yyvsp, yylsp);
 
   yystate = yyn;
   goto yynewstate;
@@ -2449,53 +2283,57 @@ yyerrlab1:
 `-------------------------------------*/
 yyacceptlab:
   yyresult = 0;
-  goto yyreturn;
+  goto yyreturnlab;
+
 
 /*-----------------------------------.
 | yyabortlab -- YYABORT comes here.  |
 `-----------------------------------*/
 yyabortlab:
   yyresult = 1;
-  goto yyreturn;
+  goto yyreturnlab;
 
-#ifndef yyoverflow
-/*-------------------------------------------------.
-| yyexhaustedlab -- memory exhaustion comes here.  |
-`-------------------------------------------------*/
+
+/*-----------------------------------------------------------.
+| yyexhaustedlab -- YYNOMEM (memory exhaustion) comes here.  |
+`-----------------------------------------------------------*/
 yyexhaustedlab:
   yyerror (YY_("memory exhausted"));
   yyresult = 2;
-  /* Fall through.  */
-#endif
+  goto yyreturnlab;
 
-yyreturn:
-  if (yychar != YYEOF && yychar != YYEMPTY)
-     yydestruct ("Cleanup: discarding lookahead",
-		 yytoken, &yylval, &yylloc);
-  /* Do not reclaim the symbols of the rule which action triggered
+
+/*----------------------------------------------------------.
+| yyreturnlab -- parsing is finished, clean up and return.  |
+`----------------------------------------------------------*/
+yyreturnlab:
+  if (yychar != YYEMPTY)
+    {
+      /* Make sure we have latest lookahead translation.  See comments at
+         user semantic actions for why this is necessary.  */
+      yytoken = YYTRANSLATE (yychar);
+      yydestruct ("Cleanup: discarding lookahead",
+                  yytoken, &yylval, &yylloc);
+    }
+  /* Do not reclaim the symbols of the rule whose action triggered
      this YYABORT or YYACCEPT.  */
   YYPOPSTACK (yylen);
   YY_STACK_PRINT (yyss, yyssp);
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-		  yystos[*yyssp], yyvsp, yylsp);
+                  YY_ACCESSING_SYMBOL (+*yyssp), yyvsp, yylsp);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow
   if (yyss != yyssa)
     YYSTACK_FREE (yyss);
 #endif
-#if YYERROR_VERBOSE
-  if (yymsg != yymsgbuf)
-    YYSTACK_FREE (yymsg);
-#endif
-  /* Make sure YYID is used.  */
-  return YYID (yyresult);
+
+  return yyresult;
 }
 
-
-#line 641 "hoa.y"
+#line 657 "hoa.y"
 
 /* Additional C code */
   
@@ -2531,4 +2369,3 @@ int parseHoa(FILE* input, HoaData* data) {
     
     return ret | autoError | semanticError;
 }
-

--- a/hoaparser.h
+++ b/hoaparser.h
@@ -1,14 +1,14 @@
-/* A Bison parser, made by GNU Bison 2.3.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
-/* Skeleton interface for Bison's Yacc-like parsers in C
+/* Bison interface for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989, 1990, 2000, 2001, 2002, 2003, 2004, 2005, 2006
-   Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
+   Inc.
 
-   This program is free software; you can redistribute it and/or modify
+   This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
-   the Free Software Foundation; either version 2, or (at your option)
-   any later version.
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
 
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -16,9 +16,7 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin Street, Fifth Floor,
-   Boston, MA 02110-1301, USA.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -33,85 +31,70 @@
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
-/* Tokens.  */
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
+
+#ifndef YY_YY_HOAPARSER_H_INCLUDED
+# define YY_YY_HOAPARSER_H_INCLUDED
+/* Debug traces.  */
+#ifndef YYDEBUG
+# define YYDEBUG 0
+#endif
+#if YYDEBUG
+extern int yydebug;
+#endif
+
+/* Token kinds.  */
 #ifndef YYTOKENTYPE
 # define YYTOKENTYPE
-   /* Put the tokens into the symbol table, so that GDB and other debuggers
-      know about them.  */
-   enum yytokentype {
-     HOAHDR = 1,
-     ACCEPTANCE = 2,
-     STATES = 3,
-     AP = 4,
-     CNTAP = 5,
-     ACCNAME = 6,
-     TOOL = 7,
-     NAME = 8,
-     START = 9,
-     ALIAS = 10,
-     PROPERTIES = 11,
-     LPAR = 258,
-     RPAR = 259,
-     LBRACE = 260,
-     RBRACE = 261,
-     LSQBRACE = 262,
-     RSQBRACE = 263,
-     BOOLOR = 264,
-     BOOLAND = 265,
-     BOOLNOT = 266,
-     STATEHDR = 267,
-     INF = 268,
-     FIN = 269,
-     BEGINBODY = 270,
-     ENDBODY = 271,
-     STRING = 272,
-     IDENTIFIER = 273,
-     ANAME = 274,
-     HEADERNAME = 275,
-     INT = 276,
-     BOOL = 277
-   };
+  enum yytokentype
+  {
+    YYEMPTY = -2,
+    YYEOF = 0,                     /* "end of file"  */
+    YYerror = 256,                 /* error  */
+    YYUNDEF = 257,                 /* "invalid token"  */
+    HOAHDR = 1,                    /* HOAHDR  */
+    ACCEPTANCE = 2,                /* ACCEPTANCE  */
+    STATES = 3,                    /* STATES  */
+    AP = 4,                        /* AP  */
+    CNTAP = 5,                     /* CNTAP  */
+    ACCNAME = 6,                   /* ACCNAME  */
+    TOOL = 7,                      /* TOOL  */
+    NAME = 8,                      /* NAME  */
+    START = 9,                     /* START  */
+    ALIAS = 10,                    /* ALIAS  */
+    PROPERTIES = 11,               /* PROPERTIES  */
+    LPAR = 258,                    /* "("  */
+    RPAR = 259,                    /* ")"  */
+    LBRACE = 260,                  /* "{"  */
+    RBRACE = 261,                  /* "}"  */
+    LSQBRACE = 262,                /* "["  */
+    RSQBRACE = 263,                /* "]"  */
+    BOOLOR = 264,                  /* "|"  */
+    BOOLAND = 265,                 /* "&"  */
+    BOOLNOT = 266,                 /* "!"  */
+    STATEHDR = 267,                /* STATEHDR  */
+    INF = 268,                     /* INF  */
+    FIN = 269,                     /* FIN  */
+    BEGINBODY = 270,               /* BEGINBODY  */
+    ENDBODY = 271,                 /* ENDBODY  */
+    STRING = 272,                  /* STRING  */
+    IDENTIFIER = 273,              /* IDENTIFIER  */
+    ANAME = 274,                   /* ANAME  */
+    HEADERNAME = 275,              /* HEADERNAME  */
+    INT = 276,                     /* INT  */
+    BOOL = 277                     /* BOOL  */
+  };
+  typedef enum yytokentype yytoken_kind_t;
 #endif
-/* Tokens.  */
-#define HOAHDR 1
-#define ACCEPTANCE 2
-#define STATES 3
-#define AP 4
-#define CNTAP 5
-#define ACCNAME 6
-#define TOOL 7
-#define NAME 8
-#define START 9
-#define ALIAS 10
-#define PROPERTIES 11
-#define LPAR 258
-#define RPAR 259
-#define LBRACE 260
-#define RBRACE 261
-#define LSQBRACE 262
-#define RSQBRACE 263
-#define BOOLOR 264
-#define BOOLAND 265
-#define BOOLNOT 266
-#define STATEHDR 267
-#define INF 268
-#define FIN 269
-#define BEGINBODY 270
-#define ENDBODY 271
-#define STRING 272
-#define IDENTIFIER 273
-#define ANAME 274
-#define HEADERNAME 275
-#define INT 276
-#define BOOL 277
 
-
-
-
+/* Value type.  */
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
-typedef union YYSTYPE
-#line 420 "hoa.y"
+union YYSTYPE
 {
+#line 436 "hoa.y"
+
     int number;
     char* string;
     bool boolean;
@@ -121,28 +104,34 @@ typedef union YYSTYPE
     void* trlist;
     void* statelist;
     BTree* tree;
-}
-/* Line 1529 of yacc.c.  */
-#line 127 "hoaparser.h"
-	YYSTYPE;
-# define yystype YYSTYPE /* obsolescent; will be withdrawn */
-# define YYSTYPE_IS_DECLARED 1
+
+#line 109 "hoaparser.h"
+
+};
+typedef union YYSTYPE YYSTYPE;
 # define YYSTYPE_IS_TRIVIAL 1
+# define YYSTYPE_IS_DECLARED 1
 #endif
 
-extern YYSTYPE yylval;
-
+/* Location type.  */
 #if ! defined YYLTYPE && ! defined YYLTYPE_IS_DECLARED
-typedef struct YYLTYPE
+typedef struct YYLTYPE YYLTYPE;
+struct YYLTYPE
 {
   int first_line;
   int first_column;
   int last_line;
   int last_column;
-} YYLTYPE;
-# define yyltype YYLTYPE /* obsolescent; will be withdrawn */
+};
 # define YYLTYPE_IS_DECLARED 1
 # define YYLTYPE_IS_TRIVIAL 1
 #endif
 
+
+extern YYSTYPE yylval;
 extern YYLTYPE yylloc;
+
+int yyparse (void);
+
+
+#endif /* !YY_YY_HOAPARSER_H_INCLUDED  */


### PR DESCRIPTION
* Add cliquegame.py: pgsolver clique game generator in extended HOA

Reimplements pgsolver's cliquegame generator directly in Python, emitting the extended HOA format so it can be consumed by the existing hoa2pg, hoa2aig, and hoacheck tools without a detour through PGSolver format.

Usage: ./cliquegame.py n [self]

* Ignore Python bytecode cache

* Add ladder/tower-of-hanoi/steady generators and bulk-game script

Reimplements pgsolver's laddergame, towersofhanoi and steadygame generators in Python with extended-HOA output. Moves all four generators (including cliquegame) into a new generators/ subdirectory and factors the HOA emission logic into generators/hoagen.py so each script stays compact.

Adds generators/generate_large.py, which runs all four generators to produce up to 20 large games each under a 10MB per-file cap, writing to generators/output/ by default (gitignored).

Note: towersofhanoi's reachable state space is 3^n, so only n=2..10 fit under 10MB; the bulk script generates the 9 sizes that fit and reports the shortfall. Output files round-trip correctly through the existing hoa2pg tool.

* Raise bison parser stack cap so hoacheck handles large HOA files

The bison-generated parser's default YYMAXDEPTH of 10000 stack items caused "memory exhausted" failures on HOA files from the new bulk generators (e.g. laddergame with 5000+ states). Set YYMAXDEPTH to 10M in hoa.y's C-declarations block; worst-case stack memory is ~160MB, trivial next to the input size.

Regenerated hoalexer.c/.h and hoaparser.c/.h with flex 2.6.4 and bison 3.8.2. All 69 large files produced by generators/generate_large.py now parse cleanly, and the existing parity-automaton examples still pass unchanged.

Also add the built binaries (hoa2aig, hoa2pg, hoacheck, hoaprint) to .gitignore.

---------